### PR TITLE
update to official OneWire lib

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -22,7 +22,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 23rd, 2015
+  Last updated by Jeff Hoefs: January 23rd, 2016
 */
 
 #include "ConfigurableFirmata.h"

--- a/src/OneWireFirmata.cpp
+++ b/src/OneWireFirmata.cpp
@@ -9,7 +9,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: November 15th, 2015
+  Last updated by Jeff Hoefs: January 23rd, 2016
 */
 
 #include <ConfigurableFirmata.h>
@@ -66,7 +66,7 @@ boolean OneWireFirmata::handleSysex(byte command, byte argc, byte* argv)
               Firmata.write(pin);
               Encoder7Bit.startBinaryWrite();
               byte addrArray[8];
-              while (isAlarmSearch ? device->search_alarms(addrArray) : device->search(addrArray)) {
+              while (isAlarmSearch ? device->search(addrArray, false) : device->search(addrArray)) {
                 for (int i = 0; i < 8; i++) {
                   Encoder7Bit.writeBinary(addrArray[i]);
                 }

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -9,7 +9,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 23rd, 2015
+  Last updated by Jeff Hoefs: January 23rd, 2016
 */
 
 #include "SerialFirmata.h"

--- a/src/SerialFirmata.h
+++ b/src/SerialFirmata.h
@@ -1,6 +1,6 @@
 /*
   SerialFirmata.h - Firmata library
-  Copyright (C) 2015 Jeff Hoefs. All rights reserved.
+  Copyright (C) 2015-2016 Jeff Hoefs. All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -9,7 +9,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 23rd, 2015
+  Last updated by Jeff Hoefs: January 23rd, 2016
 */
 
 #ifndef SerialFirmata_h

--- a/src/StepperFirmata.cpp
+++ b/src/StepperFirmata.cpp
@@ -12,7 +12,7 @@
 
   See file LICENSE.txt for further informations on licensing terms.
 
-  Last updated by Jeff Hoefs: January 23rd, 2015
+  Last updated by Jeff Hoefs: January 23rd, 2016
 */
 
 #include <ConfigurableFirmata.h>

--- a/src/utility/OneWire.cpp
+++ b/src/utility/OneWire.cpp
@@ -1,12 +1,8 @@
 /*
 Copyright (c) 2007, Jim Studt  (original old version - many contributors since)
 
-The original version of OneWire can be found at
+The latest version of this library may be found at:
   http://www.pjrc.com/teensy/td_libs_OneWire.html
-
-This version has the following changes from the original:
-- Modifications by Norbert Truchsess, January 2013
-  add search_alarms() to find only devices in alarmed state.
 
 OneWire has been maintained by Paul Stoffregen (paul@pjrc.com) since
 January 2010.  At the time, it was in need of many bug fixes, but had
@@ -30,9 +26,6 @@ Version 2.2:
   Add const qualifiers, Bertrik Sikken
   Add initial value input to crc16, Bertrik Sikken
   Add target_search() function, Scott Roberts
-
-Version 2.1 of this library was taken from:
-  http://www.pjrc.com/teensy/td_libs_OneWire.html
 
 Version 2.1:
   Arduino 1.0 compatibility, Paul Stoffregen
@@ -131,11 +124,11 @@ sample code bearing this copyright.
 
 OneWire::OneWire(uint8_t pin)
 {
-  pinMode(pin, INPUT);
-  bitmask = PIN_TO_BITMASK(pin);
-  baseReg = PIN_TO_BASEREG(pin);
+	pinMode(pin, INPUT);
+	bitmask = PIN_TO_BITMASK(pin);
+	baseReg = PIN_TO_BASEREG(pin);
 #if ONEWIRE_SEARCH
-  reset_search();
+	reset_search();
 #endif
 }
 
@@ -148,32 +141,32 @@ OneWire::OneWire(uint8_t pin)
 //
 uint8_t OneWire::reset(void)
 {
-  IO_REG_TYPE mask = bitmask;
-  volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
-  uint8_t r;
-  uint8_t retries = 125;
+	IO_REG_TYPE mask = bitmask;
+	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	uint8_t r;
+	uint8_t retries = 125;
 
-  noInterrupts();
-  DIRECT_MODE_INPUT(reg, mask);
-  interrupts();
-  // wait until the wire is high... just in case
-  do {
-    if (--retries == 0) return 0;
-    delayMicroseconds(2);
-  } while ( !DIRECT_READ(reg, mask));
+	noInterrupts();
+	DIRECT_MODE_INPUT(reg, mask);
+	interrupts();
+	// wait until the wire is high... just in case
+	do {
+		if (--retries == 0) return 0;
+		delayMicroseconds(2);
+	} while ( !DIRECT_READ(reg, mask));
 
-  noInterrupts();
-  DIRECT_WRITE_LOW(reg, mask);
-  DIRECT_MODE_OUTPUT(reg, mask);  // drive output low
-  interrupts();
-  delayMicroseconds(500);
-  noInterrupts();
-  DIRECT_MODE_INPUT(reg, mask); // allow it to float
-  delayMicroseconds(80);
-  r = !DIRECT_READ(reg, mask);
-  interrupts();
-  delayMicroseconds(420);
-  return r;
+	noInterrupts();
+	DIRECT_WRITE_LOW(reg, mask);
+	DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+	interrupts();
+	delayMicroseconds(480);
+	noInterrupts();
+	DIRECT_MODE_INPUT(reg, mask);	// allow it to float
+	delayMicroseconds(70);
+	r = !DIRECT_READ(reg, mask);
+	interrupts();
+	delayMicroseconds(410);
+	return r;
 }
 
 //
@@ -182,26 +175,26 @@ uint8_t OneWire::reset(void)
 //
 void OneWire::write_bit(uint8_t v)
 {
-  IO_REG_TYPE mask = bitmask;
-  volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	IO_REG_TYPE mask=bitmask;
+	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 
-  if (v & 1) {
-    noInterrupts();
-    DIRECT_WRITE_LOW(reg, mask);
-    DIRECT_MODE_OUTPUT(reg, mask);  // drive output low
-    delayMicroseconds(10);
-    DIRECT_WRITE_HIGH(reg, mask); // drive output high
-    interrupts();
-    delayMicroseconds(55);
-  } else {
-    noInterrupts();
-    DIRECT_WRITE_LOW(reg, mask);
-    DIRECT_MODE_OUTPUT(reg, mask);  // drive output low
-    delayMicroseconds(65);
-    DIRECT_WRITE_HIGH(reg, mask); // drive output high
-    interrupts();
-    delayMicroseconds(5);
-  }
+	if (v & 1) {
+		noInterrupts();
+		DIRECT_WRITE_LOW(reg, mask);
+		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+		delayMicroseconds(10);
+		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
+		interrupts();
+		delayMicroseconds(55);
+	} else {
+		noInterrupts();
+		DIRECT_WRITE_LOW(reg, mask);
+		DIRECT_MODE_OUTPUT(reg, mask);	// drive output low
+		delayMicroseconds(65);
+		DIRECT_WRITE_HIGH(reg, mask);	// drive output high
+		interrupts();
+		delayMicroseconds(5);
+	}
 }
 
 //
@@ -210,20 +203,20 @@ void OneWire::write_bit(uint8_t v)
 //
 uint8_t OneWire::read_bit(void)
 {
-  IO_REG_TYPE mask = bitmask;
-  volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
-  uint8_t r;
+	IO_REG_TYPE mask=bitmask;
+	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	uint8_t r;
 
-  noInterrupts();
-  DIRECT_MODE_OUTPUT(reg, mask);
-  DIRECT_WRITE_LOW(reg, mask);
-  delayMicroseconds(3);
-  DIRECT_MODE_INPUT(reg, mask); // let pin float, pull up will raise
-  delayMicroseconds(10);
-  r = DIRECT_READ(reg, mask);
-  interrupts();
-  delayMicroseconds(53);
-  return r;
+	noInterrupts();
+	DIRECT_MODE_OUTPUT(reg, mask);
+	DIRECT_WRITE_LOW(reg, mask);
+	delayMicroseconds(3);
+	DIRECT_MODE_INPUT(reg, mask);	// let pin float, pull up will raise
+	delayMicroseconds(10);
+	r = DIRECT_READ(reg, mask);
+	interrupts();
+	delayMicroseconds(53);
+	return r;
 }
 
 //
@@ -234,17 +227,17 @@ uint8_t OneWire::read_bit(void)
 // other mishap.
 //
 void OneWire::write(uint8_t v, uint8_t power /* = 0 */) {
-  uint8_t bitMask;
+    uint8_t bitMask;
 
-  for (bitMask = 0x01; bitMask; bitMask <<= 1) {
-    OneWire::write_bit( (bitMask & v) ? 1 : 0);
-  }
-  if ( !power) {
-    noInterrupts();
-    DIRECT_MODE_INPUT(baseReg, bitmask);
-    DIRECT_WRITE_LOW(baseReg, bitmask);
-    interrupts();
-  }
+    for (bitMask = 0x01; bitMask; bitMask <<= 1) {
+	OneWire::write_bit( (bitMask & v)?1:0);
+    }
+    if ( !power) {
+	noInterrupts();
+	DIRECT_MODE_INPUT(baseReg, bitmask);
+	DIRECT_WRITE_LOW(baseReg, bitmask);
+	interrupts();
+    }
 }
 
 void OneWire::write_bytes(const uint8_t *buf, uint16_t count, bool power /* = 0 */) {
@@ -262,13 +255,13 @@ void OneWire::write_bytes(const uint8_t *buf, uint16_t count, bool power /* = 0 
 // Read a byte
 //
 uint8_t OneWire::read() {
-  uint8_t bitMask;
-  uint8_t r = 0;
+    uint8_t bitMask;
+    uint8_t r = 0;
 
-  for (bitMask = 0x01; bitMask; bitMask <<= 1) {
-    if ( OneWire::read_bit()) r |= bitMask;
-  }
-  return r;
+    for (bitMask = 0x01; bitMask; bitMask <<= 1) {
+	if ( OneWire::read_bit()) r |= bitMask;
+    }
+    return r;
 }
 
 void OneWire::read_bytes(uint8_t *buf, uint16_t count) {
@@ -279,13 +272,13 @@ void OneWire::read_bytes(uint8_t *buf, uint16_t count) {
 //
 // Do a ROM select
 //
-void OneWire::select( uint8_t rom[8])
+void OneWire::select(const uint8_t rom[8])
 {
-  int i;
+    uint8_t i;
 
-  write(0x55);           // Choose ROM
+    write(0x55);           // Choose ROM
 
-  for (i = 0; i < 8; i++) write(rom[i]);
+    for (i = 0; i < 8; i++) write(rom[i]);
 }
 
 //
@@ -293,14 +286,14 @@ void OneWire::select( uint8_t rom[8])
 //
 void OneWire::skip()
 {
-  write(0xCC);           // Skip ROM
+    write(0xCC);           // Skip ROM
 }
 
 void OneWire::depower()
 {
-  noInterrupts();
-  DIRECT_MODE_INPUT(baseReg, bitmask);
-  interrupts();
+	noInterrupts();
+	DIRECT_MODE_INPUT(baseReg, bitmask);
+	interrupts();
 }
 
 #if ONEWIRE_SEARCH
@@ -315,8 +308,7 @@ void OneWire::reset_search()
   LastDiscrepancy = 0;
   LastDeviceFlag = FALSE;
   LastFamilyDiscrepancy = 0;
-  for (int i = 7; ; i--)
-  {
+  for(int i = 7; ; i--) {
     ROM_NO[i] = 0;
     if ( i == 0) break;
   }
@@ -327,13 +319,13 @@ void OneWire::reset_search()
 //
 void OneWire::target_search(uint8_t family_code)
 {
-  // set the search state to find SearchFamily type devices
-  ROM_NO[0] = family_code;
-  for (uint8_t i = 1; i < 8; i++)
-    ROM_NO[i] = 0;
-  LastDiscrepancy = 64;
-  LastFamilyDiscrepancy = 0;
-  LastDeviceFlag = FALSE;
+   // set the search state to find SearchFamily type devices
+   ROM_NO[0] = family_code;
+   for (uint8_t i = 1; i < 8; i++)
+      ROM_NO[i] = 0;
+   LastDiscrepancy = 64;
+   LastFamilyDiscrepancy = 0;
+   LastDeviceFlag = FALSE;
 }
 
 //
@@ -352,139 +344,128 @@ void OneWire::target_search(uint8_t family_code)
 // Return TRUE  : device found, ROM number in ROM_NO buffer
 //        FALSE : device not found, end of search
 //
-
-uint8_t OneWire::search(uint8_t *newAddr)
+uint8_t OneWire::search(uint8_t *newAddr, bool search_mode /* = true */)
 {
-  return search_internal(newAddr, 0xF0);
-}
+   uint8_t id_bit_number;
+   uint8_t last_zero, rom_byte_number, search_result;
+   uint8_t id_bit, cmp_id_bit;
 
-//
-// Like search. Return devices that are in alarm state only.
-//
+   unsigned char rom_byte_mask, search_direction;
 
-uint8_t OneWire::search_alarms(uint8_t *newAddr)
-{
-  return search_internal(newAddr, 0xEC);
-}
+   // initialize for search
+   id_bit_number = 1;
+   last_zero = 0;
+   rom_byte_number = 0;
+   rom_byte_mask = 1;
+   search_result = 0;
 
-uint8_t OneWire::search_internal(uint8_t *newAddr, uint8_t command)
-{
-  uint8_t id_bit_number;
-  uint8_t last_zero, rom_byte_number, search_result;
-  uint8_t id_bit, cmp_id_bit;
+   // if the last call was not the last one
+   if (!LastDeviceFlag)
+   {
+      // 1-Wire reset
+      if (!reset())
+      {
+         // reset the search
+         LastDiscrepancy = 0;
+         LastDeviceFlag = FALSE;
+         LastFamilyDiscrepancy = 0;
+         return FALSE;
+      }
 
-  unsigned char rom_byte_mask, search_direction;
+      // issue the search command
+      if (search_mode == true) {
+        write(0xF0);   // NORMAL SEARCH
+      } else {
+        write(0xEC);   // CONDITIONAL SEARCH
+      }
 
-  // initialize for search
-  id_bit_number = 1;
-  last_zero = 0;
-  rom_byte_number = 0;
-  rom_byte_mask = 1;
-  search_result = 0;
+      // loop to do the search
+      do
+      {
+         // read a bit and its complement
+         id_bit = read_bit();
+         cmp_id_bit = read_bit();
 
-  // if the last call was not the last one
-  if (!LastDeviceFlag)
-  {
-    // 1-Wire reset
-    if (!reset())
-    {
-      // reset the search
+         // check for no devices on 1-wire
+         if ((id_bit == 1) && (cmp_id_bit == 1))
+            break;
+         else
+         {
+            // all devices coupled have 0 or 1
+            if (id_bit != cmp_id_bit)
+               search_direction = id_bit;  // bit write value for search
+            else
+            {
+               // if this discrepancy if before the Last Discrepancy
+               // on a previous next then pick the same as last time
+               if (id_bit_number < LastDiscrepancy)
+                  search_direction = ((ROM_NO[rom_byte_number] & rom_byte_mask) > 0);
+               else
+                  // if equal to last pick 1, if not then pick 0
+                  search_direction = (id_bit_number == LastDiscrepancy);
+
+               // if 0 was picked then record its position in LastZero
+               if (search_direction == 0)
+               {
+                  last_zero = id_bit_number;
+
+                  // check for Last discrepancy in family
+                  if (last_zero < 9)
+                     LastFamilyDiscrepancy = last_zero;
+               }
+            }
+
+            // set or clear the bit in the ROM byte rom_byte_number
+            // with mask rom_byte_mask
+            if (search_direction == 1)
+              ROM_NO[rom_byte_number] |= rom_byte_mask;
+            else
+              ROM_NO[rom_byte_number] &= ~rom_byte_mask;
+
+            // serial number search direction write bit
+            write_bit(search_direction);
+
+            // increment the byte counter id_bit_number
+            // and shift the mask rom_byte_mask
+            id_bit_number++;
+            rom_byte_mask <<= 1;
+
+            // if the mask is 0 then go to new SerialNum byte rom_byte_number and reset mask
+            if (rom_byte_mask == 0)
+            {
+                rom_byte_number++;
+                rom_byte_mask = 1;
+            }
+         }
+      }
+      while(rom_byte_number < 8);  // loop until through all ROM bytes 0-7
+
+      // if the search was successful then
+      if (!(id_bit_number < 65))
+      {
+         // search successful so set LastDiscrepancy,LastDeviceFlag,search_result
+         LastDiscrepancy = last_zero;
+
+         // check for last device
+         if (LastDiscrepancy == 0)
+            LastDeviceFlag = TRUE;
+
+         search_result = TRUE;
+      }
+   }
+
+   // if no device found then reset counters so next 'search' will be like a first
+   if (!search_result || !ROM_NO[0])
+   {
       LastDiscrepancy = 0;
       LastDeviceFlag = FALSE;
       LastFamilyDiscrepancy = 0;
-      return FALSE;
-    }
-
-    // issue the search command
-    write(command);
-
-    // loop to do the search
-    do
-    {
-      // read a bit and its complement
-      id_bit = read_bit();
-      cmp_id_bit = read_bit();
-
-      // check for no devices on 1-wire
-      if ((id_bit == 1) && (cmp_id_bit == 1))
-        break;
-      else
-      {
-        // all devices coupled have 0 or 1
-        if (id_bit != cmp_id_bit)
-          search_direction = id_bit;  // bit write value for search
-        else
-        {
-          // if this discrepancy if before the Last Discrepancy
-          // on a previous next then pick the same as last time
-          if (id_bit_number < LastDiscrepancy)
-            search_direction = ((ROM_NO[rom_byte_number] & rom_byte_mask) > 0);
-          else
-            // if equal to last pick 1, if not then pick 0
-            search_direction = (id_bit_number == LastDiscrepancy);
-
-          // if 0 was picked then record its position in LastZero
-          if (search_direction == 0)
-          {
-            last_zero = id_bit_number;
-
-            // check for Last discrepancy in family
-            if (last_zero < 9)
-              LastFamilyDiscrepancy = last_zero;
-          }
-        }
-
-        // set or clear the bit in the ROM byte rom_byte_number
-        // with mask rom_byte_mask
-        if (search_direction == 1)
-          ROM_NO[rom_byte_number] |= rom_byte_mask;
-        else
-          ROM_NO[rom_byte_number] &= ~rom_byte_mask;
-
-        // serial number search direction write bit
-        write_bit(search_direction);
-
-        // increment the byte counter id_bit_number
-        // and shift the mask rom_byte_mask
-        id_bit_number++;
-        rom_byte_mask <<= 1;
-
-        // if the mask is 0 then go to new SerialNum byte rom_byte_number and reset mask
-        if (rom_byte_mask == 0)
-        {
-          rom_byte_number++;
-          rom_byte_mask = 1;
-        }
-      }
-    }
-    while (rom_byte_number < 8); // loop until through all ROM bytes 0-7
-
-    // if the search was successful then
-    if (!(id_bit_number < 65))
-    {
-      // search successful so set LastDiscrepancy,LastDeviceFlag,search_result
-      LastDiscrepancy = last_zero;
-
-      // check for last device
-      if (LastDiscrepancy == 0)
-        LastDeviceFlag = TRUE;
-
-      search_result = TRUE;
-    }
+      search_result = FALSE;
+   } else {
+      for (int i = 0; i < 8; i++) newAddr[i] = ROM_NO[i];
+   }
+   return search_result;
   }
-
-  // if no device found then reset counters so next 'search' will be like a first
-  if (!search_result || !ROM_NO[0])
-  {
-    LastDiscrepancy = 0;
-    LastDeviceFlag = FALSE;
-    LastFamilyDiscrepancy = 0;
-    search_result = FALSE;
-  } else {
-    for (int i = 0; i < 8; i++) newAddr[i] = ROM_NO[i];
-  }
-  return search_result;
-}
 
 #endif
 
@@ -497,23 +478,22 @@ uint8_t OneWire::search_internal(uint8_t *newAddr, uint8_t command)
 // This table comes from Dallas sample code where it is freely reusable,
 // though Copyright (C) 2000 Dallas Semiconductor Corporation
 static const uint8_t PROGMEM dscrc_table[] = {
-  0, 94, 188, 226, 97, 63, 221, 131, 194, 156, 126, 32, 163, 253, 31, 65,
-  157, 195, 33, 127, 252, 162, 64, 30, 95,  1, 227, 189, 62, 96, 130, 220,
-  35, 125, 159, 193, 66, 28, 254, 160, 225, 191, 93,  3, 128, 222, 60, 98,
-  190, 224,  2, 92, 223, 129, 99, 61, 124, 34, 192, 158, 29, 67, 161, 255,
-  70, 24, 250, 164, 39, 121, 155, 197, 132, 218, 56, 102, 229, 187, 89,  7,
-  219, 133, 103, 57, 186, 228,  6, 88, 25, 71, 165, 251, 120, 38, 196, 154,
-  101, 59, 217, 135,  4, 90, 184, 230, 167, 249, 27, 69, 198, 152, 122, 36,
-  248, 166, 68, 26, 153, 199, 37, 123, 58, 100, 134, 216, 91,  5, 231, 185,
-  140, 210, 48, 110, 237, 179, 81, 15, 78, 16, 242, 172, 47, 113, 147, 205,
-  17, 79, 173, 243, 112, 46, 204, 146, 211, 141, 111, 49, 178, 236, 14, 80,
-  175, 241, 19, 77, 206, 144, 114, 44, 109, 51, 209, 143, 12, 82, 176, 238,
-  50, 108, 142, 208, 83, 13, 239, 177, 240, 174, 76, 18, 145, 207, 45, 115,
-  202, 148, 118, 40, 171, 245, 23, 73,  8, 86, 180, 234, 105, 55, 213, 139,
-  87,  9, 235, 181, 54, 104, 138, 212, 149, 203, 41, 119, 244, 170, 72, 22,
-  233, 183, 85, 11, 136, 214, 52, 106, 43, 117, 151, 201, 74, 20, 246, 168,
-  116, 42, 200, 150, 21, 75, 169, 247, 182, 232, 10, 84, 215, 137, 107, 53
-};
+      0, 94,188,226, 97, 63,221,131,194,156,126, 32,163,253, 31, 65,
+    157,195, 33,127,252,162, 64, 30, 95,  1,227,189, 62, 96,130,220,
+     35,125,159,193, 66, 28,254,160,225,191, 93,  3,128,222, 60, 98,
+    190,224,  2, 92,223,129, 99, 61,124, 34,192,158, 29, 67,161,255,
+     70, 24,250,164, 39,121,155,197,132,218, 56,102,229,187, 89,  7,
+    219,133,103, 57,186,228,  6, 88, 25, 71,165,251,120, 38,196,154,
+    101, 59,217,135,  4, 90,184,230,167,249, 27, 69,198,152,122, 36,
+    248,166, 68, 26,153,199, 37,123, 58,100,134,216, 91,  5,231,185,
+    140,210, 48,110,237,179, 81, 15, 78, 16,242,172, 47,113,147,205,
+     17, 79,173,243,112, 46,204,146,211,141,111, 49,178,236, 14, 80,
+    175,241, 19, 77,206,144,114, 44,109, 51,209,143, 12, 82,176,238,
+     50,108,142,208, 83, 13,239,177,240,174, 76, 18,145,207, 45,115,
+    202,148,118, 40,171,245, 23, 73,  8, 86,180,234,105, 55,213,139,
+     87,  9,235,181, 54,104,138,212,149,203, 41,119,244,170, 72, 22,
+    233,183, 85, 11,136,214, 52,106, 43,117,151,201, 74, 20,246,168,
+    116, 42,200,150, 21, 75,169,247,182,232, 10, 84,215,137,107, 53};
 
 //
 // Compute a Dallas Semiconductor 8 bit CRC. These show up in the ROM
@@ -524,12 +504,12 @@ static const uint8_t PROGMEM dscrc_table[] = {
 //
 uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {
-  uint8_t crc = 0;
+	uint8_t crc = 0;
 
-  while (len--) {
-    crc = pgm_read_byte(dscrc_table + (crc ^ *addr++));
-  }
-  return crc;
+	while (len--) {
+		crc = pgm_read_byte(dscrc_table + (crc ^ *addr++));
+	}
+	return crc;
 }
 #else
 //
@@ -538,49 +518,49 @@ uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 //
 uint8_t OneWire::crc8(const uint8_t *addr, uint8_t len)
 {
-  uint8_t crc = 0;
-
-  while (len--) {
-    uint8_t inbyte = *addr++;
-    for (uint8_t i = 8; i; i--) {
-      uint8_t mix = (crc ^ inbyte) & 0x01;
-      crc >>= 1;
-      if (mix) crc ^= 0x8C;
-      inbyte >>= 1;
-    }
-  }
-  return crc;
+	uint8_t crc = 0;
+	
+	while (len--) {
+		uint8_t inbyte = *addr++;
+		for (uint8_t i = 8; i; i--) {
+			uint8_t mix = (crc ^ inbyte) & 0x01;
+			crc >>= 1;
+			if (mix) crc ^= 0x8C;
+			inbyte >>= 1;
+		}
+	}
+	return crc;
 }
 #endif
 
 #if ONEWIRE_CRC16
 bool OneWire::check_crc16(const uint8_t* input, uint16_t len, const uint8_t* inverted_crc, uint16_t crc)
 {
-  crc = ~crc16(input, len, crc);
-  return (crc & 0xFF) == inverted_crc[0] && (crc >> 8) == inverted_crc[1];
+    crc = ~crc16(input, len, crc);
+    return (crc & 0xFF) == inverted_crc[0] && (crc >> 8) == inverted_crc[1];
 }
 
 uint16_t OneWire::crc16(const uint8_t* input, uint16_t len, uint16_t crc)
 {
-  static const uint8_t oddparity[16] =
-  { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
+    static const uint8_t oddparity[16] =
+        { 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0 };
 
-  for (uint16_t i = 0 ; i < len ; i++) {
-    // Even though we're just copying a byte from the input,
-    // we'll be doing 16-bit computation with it.
-    uint16_t cdata = input[i];
-    cdata = (cdata ^ (crc & 0xff)) & 0xff;
-    crc >>= 8;
+    for (uint16_t i = 0 ; i < len ; i++) {
+      // Even though we're just copying a byte from the input,
+      // we'll be doing 16-bit computation with it.
+      uint16_t cdata = input[i];
+      cdata = (cdata ^ crc) & 0xff;
+      crc >>= 8;
 
-    if (oddparity[cdata & 0x0F] ^ oddparity[cdata >> 4])
-      crc ^= 0xC001;
+      if (oddparity[cdata & 0x0F] ^ oddparity[cdata >> 4])
+          crc ^= 0xC001;
 
-    cdata <<= 6;
-    crc ^= cdata;
-    cdata <<= 1;
-    crc ^= cdata;
-  }
-  return crc;
+      cdata <<= 6;
+      crc ^= cdata;
+      cdata <<= 1;
+      crc ^= cdata;
+    }
+    return crc;
 }
 #endif
 

--- a/src/utility/OneWire.h
+++ b/src/utility/OneWire.h
@@ -45,8 +45,12 @@
 #define ONEWIRE_CRC16 1
 #endif
 
+#ifndef FALSE
 #define FALSE 0
+#endif
+#ifndef TRUE
 #define TRUE  1
+#endif
 
 // Platform specific I/O definitions
 
@@ -56,12 +60,12 @@
 #define IO_REG_TYPE uint8_t
 #define IO_REG_ASM asm("r30")
 #define DIRECT_READ(base, mask)         (((*(base)) & (mask)) ? 1 : 0)
-#define DIRECT_MODE_INPUT(base, mask)   ((*(base+1)) &= ~(mask))
-#define DIRECT_MODE_OUTPUT(base, mask)  ((*(base+1)) |= (mask))
-#define DIRECT_WRITE_LOW(base, mask)    ((*(base+2)) &= ~(mask))
-#define DIRECT_WRITE_HIGH(base, mask)   ((*(base+2)) |= (mask))
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+1)) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+2)) &= ~(mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+2)) |= (mask))
 
-#elif defined(__MK20DX128__) || defined(__MK20DX256__)
+#elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK66FX1M0__) || defined(__MK64FX512__)
 #define PIN_TO_BASEREG(pin)             (portOutputRegister(pin))
 #define PIN_TO_BITMASK(pin)             (1)
 #define IO_REG_TYPE uint8_t
@@ -105,7 +109,6 @@
 #endif
 
 #elif defined(__PIC32MX__)
-#include <plib.h>  // is this necessary?
 #define PIN_TO_BASEREG(pin)             (portModeRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
 #define IO_REG_TYPE uint32_t
@@ -115,6 +118,119 @@
 #define DIRECT_MODE_OUTPUT(base, mask)  ((*(base+1)) = (mask))            //TRISXCLR + 0x04
 #define DIRECT_WRITE_LOW(base, mask)    ((*(base+8+1)) = (mask))          //LATXCLR  + 0x24
 #define DIRECT_WRITE_HIGH(base, mask)   ((*(base+8+2)) = (mask))          //LATXSET + 0x28
+
+#elif defined(ARDUINO_ARCH_ESP8266)
+#define PIN_TO_BASEREG(pin)             ((volatile uint32_t*) GPO)
+#define PIN_TO_BITMASK(pin)             (1 << pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_ASM
+#define DIRECT_READ(base, mask)         ((GPI & (mask)) ? 1 : 0)    //GPIO_IN_ADDRESS
+#define DIRECT_MODE_INPUT(base, mask)   (GPE &= ~(mask))            //GPIO_ENABLE_W1TC_ADDRESS
+#define DIRECT_MODE_OUTPUT(base, mask)  (GPE |= (mask))             //GPIO_ENABLE_W1TS_ADDRESS
+#define DIRECT_WRITE_LOW(base, mask)    (GPOC = (mask))             //GPIO_OUT_W1TC_ADDRESS
+#define DIRECT_WRITE_HIGH(base, mask)   (GPOS = (mask))             //GPIO_OUT_W1TS_ADDRESS
+
+#elif defined(__SAMD21G18A__)
+#define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define IO_REG_TYPE uint32_t
+#define IO_REG_ASM
+#define DIRECT_READ(base, mask)         (((*((base)+8)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base)+1)) = (mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base)+2)) = (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+5)) = (mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask))
+
+#elif defined(RBL_NRF51822)
+#define PIN_TO_BASEREG(pin)             (0)
+#define PIN_TO_BITMASK(pin)             (pin)
+#define IO_REG_TYPE uint32_t
+#define IO_REG_ASM
+#define DIRECT_READ(base, pin)          nrf_gpio_pin_read(pin)
+#define DIRECT_WRITE_LOW(base, pin)     nrf_gpio_pin_clear(pin)
+#define DIRECT_WRITE_HIGH(base, pin)    nrf_gpio_pin_set(pin)
+#define DIRECT_MODE_INPUT(base, pin)    nrf_gpio_cfg_input(pin, NRF_GPIO_PIN_NOPULL)
+#define DIRECT_MODE_OUTPUT(base, pin)   nrf_gpio_cfg_output(pin)
+
+#elif defined(__arc__) /* Arduino101/Genuino101 specifics */
+
+#include "scss_registers.h"
+#include "portable.h"
+#include "avr/pgmspace.h"
+
+#define GPIO_ID(pin)			(g_APinDescription[pin].ulGPIOId)
+#define GPIO_TYPE(pin)			(g_APinDescription[pin].ulGPIOType)
+#define GPIO_BASE(pin)			(g_APinDescription[pin].ulGPIOBase)
+#define DIR_OFFSET_SS			0x01
+#define DIR_OFFSET_SOC			0x04
+#define EXT_PORT_OFFSET_SS		0x0A
+#define EXT_PORT_OFFSET_SOC		0x50
+
+/* GPIO registers base address */
+#define PIN_TO_BASEREG(pin)		((volatile uint32_t *)g_APinDescription[pin].ulGPIOBase)
+#define PIN_TO_BITMASK(pin)		pin
+#define IO_REG_TYPE			uint32_t
+#define IO_REG_ASM
+
+static inline __attribute__((always_inline))
+IO_REG_TYPE directRead(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    IO_REG_TYPE ret;
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        ret = READ_ARC_REG(((IO_REG_TYPE)base + EXT_PORT_OFFSET_SS));
+    } else {
+        ret = MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, EXT_PORT_OFFSET_SOC);
+    }
+    return ((ret >> GPIO_ID(pin)) & 0x01);
+}
+
+static inline __attribute__((always_inline))
+void directModeInput(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG((((IO_REG_TYPE)base) + DIR_OFFSET_SS)) & ~(0x01 << GPIO_ID(pin)),
+			((IO_REG_TYPE)(base) + DIR_OFFSET_SS));
+    } else {
+        MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, DIR_OFFSET_SOC) &= ~(0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directModeOutput(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(((IO_REG_TYPE)(base) + DIR_OFFSET_SS)) | (0x01 << GPIO_ID(pin)),
+			((IO_REG_TYPE)(base) + DIR_OFFSET_SS));
+    } else {
+        MMIO_REG_VAL_FROM_BASE((IO_REG_TYPE)base, DIR_OFFSET_SOC) |= (0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directWriteLow(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(base) & ~(0x01 << GPIO_ID(pin)), base);
+    } else {
+        MMIO_REG_VAL(base) &= ~(0x01 << GPIO_ID(pin));
+    }
+}
+
+static inline __attribute__((always_inline))
+void directWriteHigh(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
+{
+    if (SS_GPIO == GPIO_TYPE(pin)) {
+        WRITE_ARC_REG(READ_ARC_REG(base) | (0x01 << GPIO_ID(pin)), base);
+    } else {
+        MMIO_REG_VAL(base) |= (0x01 << GPIO_ID(pin));
+    }
+}
+
+#define DIRECT_READ(base, pin)		directRead(base, pin)
+#define DIRECT_MODE_INPUT(base, pin)	directModeInput(base, pin)
+#define DIRECT_MODE_OUTPUT(base, pin)	directModeOutput(base, pin)
+#define DIRECT_WRITE_LOW(base, pin)	directWriteLow(base, pin)
+#define DIRECT_WRITE_HIGH(base, pin)	directWriteHigh(base, pin)
 
 #else
 #define PIN_TO_BASEREG(pin)             (0)
@@ -143,8 +259,6 @@ class OneWire
     uint8_t LastDiscrepancy;
     uint8_t LastFamilyDiscrepancy;
     uint8_t LastDeviceFlag;
-
-    uint8_t search_internal(uint8_t *newAddr, uint8_t command);
 #endif
 
   public:
@@ -156,7 +270,7 @@ class OneWire
     uint8_t reset(void);
 
     // Issue a 1-Wire rom select command, you do the reset first.
-    void select( uint8_t rom[8]);
+    void select(const uint8_t rom[8]);
 
     // Issue a 1-Wire rom skip command, to address all on bus.
     void skip(void);
@@ -202,10 +316,7 @@ class OneWire
     // might be a good idea to check the CRC to make sure you didn't
     // get garbage.  The order is deterministic. You will always get
     // the same devices in the same order.
-    uint8_t search(uint8_t *newAddr);
-
-    // Like search, but finds devices in alarmed state only.
-    uint8_t search_alarms(uint8_t *newAddr);
+    uint8_t search(uint8_t *newAddr, bool search_mode = true);
 #endif
 
 #if ONEWIRE_CRC
@@ -225,8 +336,8 @@ class OneWire
     //    ReadBytes(net, buf+3, 10);  // Read 6 data bytes, 2 0xFF, 2 CRC16
     //    if (!CheckCRC16(buf, 11, &buf[11])) {
     //        // Handle error.
-    //    }
-    //
+    //    }     
+    //          
     // @param input - Array of bytes to checksum.
     // @param len - How many bytes to use.
     // @param inverted_crc - The two CRC16 bytes in the received data.


### PR DESCRIPTION
Now using OneWire from https://github.com/PaulStoffregen/OneWire since the `search_alarms` function is no longer necessary (as of OneWire 2.3.2 you can simply pass "false" as 2nd argument to `search` function to achieve what `search_alarms` was previously used for).

The OneWire library is still copied into ConfigurableFirmata. It should be removed in a future release and users should obtain OneWire separately (Arduino Library manager or direct download or clone).