### PR TITLE
SerialFirmata: store&forward incoming bytes

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -178,6 +178,9 @@ OneWireFirmata oneWire;
 #include <StepperFirmata.h>
 StepperFirmata stepper;
 
+//uncomment SERIAL_STORE_AND_FORWARD to collect bytes received by serial port until the receive buffer 
+// gets filled or a data gap is detected to avoid forwarding single bytes at baud rates below 50000
+//#define SERIAL_STORE_AND_FORWARD
 #include <SerialFirmata.h>
 SerialFirmata serial;
 

--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -178,9 +178,6 @@ OneWireFirmata oneWire;
 #include <StepperFirmata.h>
 StepperFirmata stepper;
 
-//uncomment SERIAL_STORE_AND_FORWARD to collect bytes received by serial port until the receive buffer 
-// gets filled or a data gap is detected to avoid forwarding single bytes at baud rates below 50000
-//#define SERIAL_STORE_AND_FORWARD
 #include <SerialFirmata.h>
 SerialFirmata serial;
 

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -55,10 +55,10 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
         {
           long baud = (long)argv[1] | ((long)argv[2] << 7) | ((long)argv[3] << 14);
           serial_pins pins;
-#if defined(SERIAL_STORE_AND_FORWARD)    
+#if defined(FIRMATA_SERIAL_PORT_RX_BUFFERING)    
           lastAvailableBytes[portId] = 0;
           lastReceive[portId] = 0;
-          maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay 
+          maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char, max. 50 bits -> 50000 = 50bits * 1000ms/s
 #endif              
           if (portId < 8) {
             serialPort = getPortFromId(portId);
@@ -287,7 +287,7 @@ void SerialFirmata::checkSerial()
 
   if (serialIndex > -1) {
 
-#if defined(SERIAL_STORE_AND_FORWARD)
+#if defined(FIRMATA_SERIAL_PORT_RX_BUFFERING)
     unsigned long currentMillis = millis();
 #endif
 
@@ -309,7 +309,7 @@ void SerialFirmata::checkSerial()
       if (availableBytes > 0) {
         bool read = true;
 
-#if defined(SERIAL_STORE_AND_FORWARD)
+#if defined(FIRMATA_SERIAL_PORT_RX_BUFFERING)
         // check if reading should be delayed to collect some bytes before
         // forwarding (for baud rates significantly below 57600 baud)
         if (maxCharDelay[portId]) {
@@ -334,7 +334,9 @@ void SerialFirmata::checkSerial()
             numBytesToRead = bytesToRead;
           }
           
+#if defined(FIRMATA_SERIAL_PORT_RX_BUFFERING)
           lastAvailableBytes[portId] -= numBytesToRead; 
+#endif
 
           // relay serial data to the serial device
           while (numBytesToRead > 0) {

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -49,162 +49,159 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
     byte mode = argv[0] & SERIAL_MODE_MASK;
     byte portId = argv[0] & SERIAL_PORT_ID_MASK;
 
-    switch (mode) {
-      case SERIAL_CONFIG:
-        {
-          long baud = (long)argv[1] | ((long)argv[2] << 7) | ((long)argv[3] << 14);
-          serial_pins pins;
-
-          if (portId < 8) {
-            serialPort = getPortFromId(portId);
-            if (serialPort != NULL) {
-              pins = getSerialPinNumbers(portId);
-              if (pins.rx != 0 && pins.tx != 0) {
-                Firmata.setPinMode(pins.rx, PIN_MODE_SERIAL);
-                Firmata.setPinMode(pins.tx, PIN_MODE_SERIAL);
-                // Fixes an issue where some serial devices would not work properly with Arduino Due
-                // because all Arduino pins are set to OUTPUT by default in StandardFirmata.
-                pinMode(pins.rx, INPUT);
+    if (portId < SERIAL_READ_ARR_LEN)
+    {
+      switch (mode) {
+        case SERIAL_CONFIG:
+          {
+            long baud = (long)argv[1] | ((long)argv[2] << 7) | ((long)argv[3] << 14);
+            serial_pins pins;
+#if defined(SERIAL_STORE_AND_FORWARD)
+            lastAvailableBytes[portId] = 0;
+            lastReceive[portId] = 0;
+            maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay
+#endif
+            if (portId < 8) {
+              serialPort = getPortFromId(portId);
+              if (serialPort != NULL) {
+                pins = getSerialPinNumbers(portId);
+                if (pins.rx != 0 && pins.tx != 0) {
+                  Firmata.setPinMode(pins.rx, PIN_MODE_SERIAL);
+                  Firmata.setPinMode(pins.tx, PIN_MODE_SERIAL);
+                  // Fixes an issue where some serial devices would not work properly with Arduino Due
+                  // because all Arduino pins are set to OUTPUT by default in StandardFirmata.
+                  pinMode(pins.rx, INPUT);
+                }
+                ((HardwareSerial*)serialPort)->begin(baud);
               }
-#if defined(SERIAL_STORE_AND_FORWARD)    
-              lastAvailableBytes[portId] = 0;
-              lastReceive[portId] = 0;
-              maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay 
-#endif              
-              ((HardwareSerial*)serialPort)->begin(baud);
-            }
-          } else {
-#if defined(SoftwareSerial_h)
-            byte swTxPin, swRxPin;
-            if (argc > 4) {
-              swRxPin = argv[4];
-              swTxPin = argv[5];
             } else {
-              // RX and TX pins must be specified when using software serial
-              Firmata.sendString("Specify serial RX and TX pins");
-              return false;
+#if defined(SoftwareSerial_h)
+              byte swTxPin, swRxPin;
+              if (argc > 4) {
+                swRxPin = argv[4];
+                swTxPin = argv[5];
+              } else {
+                // RX and TX pins must be specified when using software serial
+                Firmata.sendString("Specify serial RX and TX pins");
+                return false;
+              }
+              switch (portId) {
+                case SW_SERIAL0:
+                  if (swSerial0 == NULL) {
+                    swSerial0 = new SoftwareSerial(swRxPin, swTxPin);
+                  }
+                  break;
+                case SW_SERIAL1:
+                  if (swSerial1 == NULL) {
+                    swSerial1 = new SoftwareSerial(swRxPin, swTxPin);
+                  }
+                  break;
+                case SW_SERIAL2:
+                  if (swSerial2 == NULL) {
+                    swSerial2 = new SoftwareSerial(swRxPin, swTxPin);
+                  }
+                  break;
+                case SW_SERIAL3:
+                  if (swSerial3 == NULL) {
+                    swSerial3 = new SoftwareSerial(swRxPin, swTxPin);
+                  }
+                  break;
+              }
+              serialPort = getPortFromId(portId);
+              if (serialPort != NULL) {
+                Firmata.setPinMode(swRxPin, PIN_MODE_SERIAL);
+                Firmata.setPinMode(swTxPin, PIN_MODE_SERIAL);
+                ((SoftwareSerial*)serialPort)->begin(baud);
+              }
+#endif
             }
-            switch (portId) {
-              case SW_SERIAL0:
-                if (swSerial0 == NULL) {
-                  swSerial0 = new SoftwareSerial(swRxPin, swTxPin);
-                }
-                break;
-              case SW_SERIAL1:
-                if (swSerial1 == NULL) {
-                  swSerial1 = new SoftwareSerial(swRxPin, swTxPin);
-                }
-                break;
-              case SW_SERIAL2:
-                if (swSerial2 == NULL) {
-                  swSerial2 = new SoftwareSerial(swRxPin, swTxPin);
-                }
-                break;
-              case SW_SERIAL3:
-                if (swSerial3 == NULL) {
-                  swSerial3 = new SoftwareSerial(swRxPin, swTxPin);
-                }
-                break;
-            }
+            break; // SERIAL_CONFIG
+          }
+        case SERIAL_WRITE:
+          {
+            byte data;
             serialPort = getPortFromId(portId);
-            if (serialPort != NULL) {
-              Firmata.setPinMode(swRxPin, PIN_MODE_SERIAL);
-              Firmata.setPinMode(swTxPin, PIN_MODE_SERIAL);
-#if defined(SERIAL_STORE_AND_FORWARD)    
-              lastAvailableBytes[portId] = 0;
-              lastReceive[portId] = 0;
-              maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay 
-#endif              
-              ((SoftwareSerial*)serialPort)->begin(baud);
+            if (serialPort == NULL) {
+              break;
             }
-#endif
+            for (byte i = 1; i < argc; i += 2) {
+              data = argv[i] + (argv[i + 1] << 7);
+              serialPort->write(data);
+            }
+            break; // SERIAL_WRITE
           }
-          break; // SERIAL_CONFIG
-        }
-      case SERIAL_WRITE:
-        {
-          byte data;
-          serialPort = getPortFromId(portId);
-          if (serialPort == NULL) {
-            break;
-          }
-          for (byte i = 1; i < argc; i += 2) {
-            data = argv[i] + (argv[i + 1] << 7);
-            serialPort->write(data);
-          }
-          break; // SERIAL_WRITE
-        }
-      case SERIAL_READ:
-        if (argv[1] == SERIAL_READ_CONTINUOUSLY) {
-          if (serialIndex + 1 >= MAX_SERIAL_PORTS) {
-            break;
-          }
+        case SERIAL_READ:
+          if (argv[1] == SERIAL_READ_CONTINUOUSLY) {
+            if (serialIndex + 1 >= MAX_SERIAL_PORTS) {
+              break;
+            }
 
-          if (argc > 2) {
-            // maximum number of bytes to read from buffer per iteration of loop()
-            serialBytesToRead[portId] = (int)argv[2] | ((int)argv[3] << 7);
-          } else {
-            // read all available bytes per iteration of loop()
-            serialBytesToRead[portId] = 0;
-          }
-          serialIndex++;
-          reportSerial[serialIndex] = portId;
-        } else if (argv[1] == SERIAL_STOP_READING) {
-          byte serialIndexToSkip = 0;
-          if (serialIndex <= 0) {
-            serialIndex = -1;
-          } else {
-            for (byte i = 0; i < serialIndex + 1; i++) {
-              if (reportSerial[i] == portId) {
-                serialIndexToSkip = i;
-                break;
+            if (argc > 2) {
+              // maximum number of bytes to read from buffer per iteration of loop()
+              serialBytesToRead[portId] = (int)argv[2] | ((int)argv[3] << 7);
+            } else {
+              // read all available bytes per iteration of loop()
+              serialBytesToRead[portId] = 0;
+            }
+            serialIndex++;
+            reportSerial[serialIndex] = portId;
+          } else if (argv[1] == SERIAL_STOP_READING) {
+            byte serialIndexToSkip = 0;
+            if (serialIndex <= 0) {
+              serialIndex = -1;
+            } else {
+              for (byte i = 0; i < serialIndex + 1; i++) {
+                if (reportSerial[i] == portId) {
+                  serialIndexToSkip = i;
+                  break;
+                }
               }
-            }
-            // shift elements over to fill space left by removed element
-            for (byte i = serialIndexToSkip; i < serialIndex + 1; i++) {
-              if (i < MAX_SERIAL_PORTS) {
-                reportSerial[i] = reportSerial[i + 1];
+              // shift elements over to fill space left by removed element
+              for (byte i = serialIndexToSkip; i < serialIndex + 1; i++) {
+                if (i < MAX_SERIAL_PORTS) {
+                  reportSerial[i] = reportSerial[i + 1];
+                }
               }
+              serialIndex--;
             }
-            serialIndex--;
           }
-        }
-        break; // SERIAL_READ
-      case SERIAL_CLOSE:
-        serialPort = getPortFromId(portId);
-        if (serialPort != NULL) {
-          if (portId < 8) {
-            ((HardwareSerial*)serialPort)->end();
-          } else {
-#if defined(SoftwareSerial_h)
-            ((SoftwareSerial*)serialPort)->end();
-            if (serialPort != NULL) {
-              free(serialPort);
-              serialPort = NULL;
-            }
-#endif
-          }
-        }
-        break; // SERIAL_CLOSE
-      case SERIAL_FLUSH:
-        serialPort = getPortFromId(portId);
-        if (serialPort != NULL) {
-          getPortFromId(portId)->flush();
-        }
-        break; // SERIAL_FLUSH
-#if defined(SoftwareSerial_h)
-      case SERIAL_LISTEN:
-        // can only call listen() on software serial ports
-        if (portId > 7) {
+          break; // SERIAL_READ
+        case SERIAL_CLOSE:
           serialPort = getPortFromId(portId);
           if (serialPort != NULL) {
-            ((SoftwareSerial*)serialPort)->listen();
-          }
-        }
-        break; // SERIAL_LISTEN
+            if (portId < 8) {
+              ((HardwareSerial*)serialPort)->end();
+            } else {
+#if defined(SoftwareSerial_h)
+              ((SoftwareSerial*)serialPort)->end();
+              if (serialPort != NULL) {
+                free(serialPort);
+                serialPort = NULL;
+              }
 #endif
+            }
+          }
+          break; // SERIAL_CLOSE
+        case SERIAL_FLUSH:
+          serialPort = getPortFromId(portId);
+          if (serialPort != NULL) {
+            getPortFromId(portId)->flush();
+          }
+          break; // SERIAL_FLUSH
+#if defined(SoftwareSerial_h)
+        case SERIAL_LISTEN:
+          // can only call listen() on software serial ports
+          if (portId > 7) {
+            serialPort = getPortFromId(portId);
+            if (serialPort != NULL) {
+              ((SoftwareSerial*)serialPort)->listen();
+            }
+          }
+          break; // SERIAL_LISTEN
+#endif
+      }
+      return true;
     }
-    return true;
   }
   return false;
 }
@@ -315,10 +312,12 @@ void SerialFirmata::checkSerial()
         bool read = true;
         
 #if defined(SERIAL_STORE_AND_FORWARD)    
-        // check if reading should be delayed to collect some bytes before forwarding (for baud rates up to 19200)
-        if (maxCharDelay[portId]) {          
-          // inter character delay exceeded or more than 48 bytes available or more bytes available than required          
-          read = (lastAvailableBytes[portId] > 0 && (currentMillis - lastReceive[portId]) >= maxCharDelay[portId]) || (bytesToRead == 0 && availableBytes >= 48) || (bytesToRead > 0 && availableBytes >= bytesToRead);
+        // check if reading should be delayed to collect some bytes before
+        // forwarding (for baud rates significantly below 57600 baud)
+        if (maxCharDelay[portId]) {
+          // inter character delay exceeded or more than 48 bytes available or more bytes available than required
+          read = (lastAvailableBytes[portId] > 0 && (currentMillis - lastReceive[portId]) >= maxCharDelay[portId])
+                 || (bytesToRead == 0 && availableBytes >= 48) || (bytesToRead > 0 && availableBytes >= bytesToRead);
           if (availableBytes > lastAvailableBytes[portId]) {
             lastReceive[portId] = currentMillis;
             lastAvailableBytes[portId] = availableBytes;

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -66,6 +66,11 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
                 // because all Arduino pins are set to OUTPUT by default in StandardFirmata.
                 pinMode(pins.rx, INPUT);
               }
+#if defined(SERIAL_STORE_AND_FORWARD)    
+              lastAvailableBytes[portId] = 0;
+              lastReceive[portId] = 0;
+              maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay 
+#endif              
               ((HardwareSerial*)serialPort)->begin(baud);
             }
           } else {
@@ -105,6 +110,11 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
             if (serialPort != NULL) {
               Firmata.setPinMode(swRxPin, PIN_MODE_SERIAL);
               Firmata.setPinMode(swTxPin, PIN_MODE_SERIAL);
+#if defined(SERIAL_STORE_AND_FORWARD)    
+              lastAvailableBytes[portId] = 0;
+              lastReceive[portId] = 0;
+              maxCharDelay[portId] = 50000 / baud; // 8N1 = 10 bits per char -> 50 bits max. char/char delay 
+#endif              
               ((SoftwareSerial*)serialPort)->begin(baud);
             }
 #endif
@@ -282,6 +292,10 @@ void SerialFirmata::checkSerial()
 
   if (serialIndex > -1) {
 
+#if defined(SERIAL_STORE_AND_FORWARD)    
+    unsigned long currentMillis = millis();
+#endif
+
     // loop through all reporting (READ_CONTINUOUS) serial ports
     for (byte i = 0; i < serialIndex + 1; i++) {
       portId = reportSerial[i];
@@ -296,27 +310,43 @@ void SerialFirmata::checkSerial()
         continue;
       }
 #endif
-      if (serialPort->available() > 0) {
-        Firmata.write(START_SYSEX);
-        Firmata.write(SERIAL_MESSAGE);
-        Firmata.write(SERIAL_REPLY | portId);
-
-        if (bytesToRead == 0 || (serialPort->available() <= bytesToRead)) {
-          numBytesToRead = serialPort->available();
-        } else {
-          numBytesToRead = bytesToRead;
+      int availableBytes = serialPort->available();
+      if (availableBytes > 0) {
+        bool read = true;
+        
+#if defined(SERIAL_STORE_AND_FORWARD)    
+        // check if reading should be delayed to collect some bytes before forwarding (for baud rates up to 19200)
+        if (maxCharDelay[portId]) {          
+          // inter character delay exceeded or more than 48 bytes available or more bytes available than required          
+          read = (lastAvailableBytes[portId] > 0 && (currentMillis - lastReceive[portId]) >= maxCharDelay[portId]) || (bytesToRead == 0 && availableBytes >= 48) || (bytesToRead > 0 && availableBytes >= bytesToRead);
+          if (availableBytes > lastAvailableBytes[portId]) {
+            lastReceive[portId] = currentMillis;
+            lastAvailableBytes[portId] = availableBytes;
+          }
         }
+#endif
 
-        // relay serial data to the serial device
-        while (numBytesToRead > 0) {
-          serialData = serialPort->read();
-          Firmata.write(serialData & 0x7F);
-          Firmata.write((serialData >> 7) & 0x7F);
-          numBytesToRead--;
+        if (read) {
+          Firmata.write(START_SYSEX);
+          Firmata.write(SERIAL_MESSAGE);
+          Firmata.write(SERIAL_REPLY | portId);
+
+          if (bytesToRead == 0 || (serialPort->available() <= bytesToRead)) {
+            numBytesToRead = serialPort->available();
+          } else {
+            numBytesToRead = bytesToRead;
+          }
+
+          // relay serial data to the serial device
+          while (numBytesToRead > 0) {
+            serialData = serialPort->read();
+            Firmata.write(serialData & 0x7F);
+            Firmata.write((serialData >> 7) & 0x7F);
+            numBytesToRead--;
+          }
+          Firmata.write(END_SYSEX);
         }
-        Firmata.write(END_SYSEX);
       }
-
     }
   }
 }

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -333,6 +333,8 @@ void SerialFirmata::checkSerial()
           } else {
             numBytesToRead = bytesToRead;
           }
+          
+          lastAvailableBytes[portId] -= numBytesToRead; 
 
           // relay serial data to the serial device
           while (numBytesToRead > 0) {

--- a/src/SerialFirmata.h
+++ b/src/SerialFirmata.h
@@ -23,9 +23,9 @@
 #include <SoftwareSerial.h>
 #endif
 
-//uncomment SERIAL_STORE_AND_FORWARD to collect bytes received by serial port until the receive buffer 
+//uncomment FIRMATA_SERIAL_PORT_RX_BUFFERING to collect bytes received by serial port until the receive buffer 
 // gets filled or a data gap is detected to avoid forwarding single bytes at baud rates below 50000
-//#define SERIAL_STORE_AND_FORWARD
+//#define FIRMATA_SERIAL_PORT_RX_BUFFERING
 
 // Serial port Ids
 #define HW_SERIAL0                  0x00
@@ -146,7 +146,7 @@ class SerialFirmata: public FirmataFeature
     int serialBytesToRead[SERIAL_READ_ARR_LEN];
     signed char serialIndex;
 
-#if defined(SERIAL_STORE_AND_FORWARD)    
+#if defined(FIRMATA_SERIAL_PORT_RX_BUFFERING)    
     unsigned long lastReceive[SERIAL_READ_ARR_LEN];
     unsigned char maxCharDelay[SERIAL_READ_ARR_LEN];
     int lastAvailableBytes[SERIAL_READ_ARR_LEN];

--- a/src/SerialFirmata.h
+++ b/src/SerialFirmata.h
@@ -23,6 +23,10 @@
 #include <SoftwareSerial.h>
 #endif
 
+//uncomment SERIAL_STORE_AND_FORWARD to collect bytes received by serial port until the receive buffer 
+// gets filled or a data gap is detected to avoid forwarding single bytes at baud rates below 50000
+//#define SERIAL_STORE_AND_FORWARD
+
 // Serial port Ids
 #define HW_SERIAL0                  0x00
 #define HW_SERIAL1                  0x01

--- a/src/SerialFirmata.h
+++ b/src/SerialFirmata.h
@@ -142,6 +142,12 @@ class SerialFirmata: public FirmataFeature
     int serialBytesToRead[SERIAL_READ_ARR_LEN];
     signed char serialIndex;
 
+#if defined(SERIAL_STORE_AND_FORWARD)    
+    unsigned long lastReceive[SERIAL_READ_ARR_LEN];
+    unsigned char maxCharDelay[SERIAL_READ_ARR_LEN];
+    int lastAvailableBytes[SERIAL_READ_ARR_LEN];
+#endif
+    
     Stream *swSerial0;
     Stream *swSerial1;
     Stream *swSerial2;


### PR DESCRIPTION
timed buffering of incoming bytes at lower baud rates typically result
in message transfers instead of single byte transfers to the host (host
offloading)