### PR TITLE
Initial pass at ESP32 support

### DIFF
--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -52,7 +52,8 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, int value)
         // Send pin value immediately. This is helpful when connected via
         // ethernet, wi-fi or bluetooth so pin states can be known upon
         // reconnecting.
-        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        // Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        Firmata.sendAnalog(analogPin, analogRead(analogInputToDigitalPin(analogPin)));
       }
     }
   }
@@ -79,7 +80,11 @@ void AnalogInputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_ANALOG(pin)) {
     Firmata.write(PIN_MODE_ANALOG);
+#ifdef DEFAULT_ADC_RESOLUTION
+    Firmata.write(DEFAULT_ADC_RESOLUTION);
+#elif
     Firmata.write(10); // 10 = 10-bit resolution
+#endif
   }
 }
 
@@ -102,7 +107,8 @@ void AnalogInputFirmata::report()
     if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {
       analogPin = PIN_TO_ANALOG(pin);
       if (analogInputsToReport & (1 << analogPin)) {
-        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        // Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        Firmata.sendAnalog(analogPin, analogRead(analogInputToDigitalPin(analogPin)));
       }
     }
   }

--- a/src/AnalogOutputFirmata.cpp
+++ b/src/AnalogOutputFirmata.cpp
@@ -20,6 +20,11 @@
 #include "AnalogFirmata.h"
 #include "AnalogOutputFirmata.h"
 
+// Hack to compile for ESP32 boards until arduino-esp32 supports analogWrite
+#ifdef ESP32
+void analogWrite(byte pin, int value);
+#endif
+
 AnalogOutputFirmata::AnalogOutputFirmata()
 {
   Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -100,8 +100,8 @@
 #define SYSEX_SAMPLING_INTERVAL 0x7A // same as SAMPLING_INTERVAL
 
 // pin modes
-//#define INPUT                 0x00 // defined in Arduino.h
-//#define OUTPUT                0x01 // defined in Arduino.h
+#define PIN_MODE_INPUT          0x00 // pin connfigured for digital input
+#define PIN_MODE_OUTPUT         0x01 // pin configured for digital output
 #define PIN_MODE_ANALOG         0x02 // analog pin in analogInput mode
 #define PIN_MODE_PWM            0x03 // digital pin in PWM output mode
 #define PIN_MODE_SERVO          0x04 // digital pin in Servo output mode
@@ -115,7 +115,9 @@
 #define PIN_MODE_IGNORE         0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
 #define TOTAL_PIN_MODES         13
 // DEPRECATED as of Firmata v2.5
-#define ANALOG                  0x02 // same as PIN_MODE_ANALOG
+// #undef ANALOG
+// #define ANALOG                  0x02 // same as PIN_MODE_ANALOG
+#undef PWM
 #define PWM                     0x03 // same as PIN_MODE_PWM
 #define SERVO                   0x04 // same as PIN_MODE_SERVO
 #define SHIFT                   0x05 // same as PIN_MODE_SHIFT

--- a/src/DigitalInputFirmata.cpp
+++ b/src/DigitalInputFirmata.cpp
@@ -91,9 +91,9 @@ void DigitalInputFirmata::reportDigital(byte port, int value)
 boolean DigitalInputFirmata::handlePinMode(byte pin, int mode)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    if (mode == INPUT || mode == PIN_MODE_PULLUP) {
+    if (mode == PIN_MODE_INPUT || mode == PIN_MODE_PULLUP) {
       portConfigInputs[pin / 8] |= (1 << (pin & 7));
-      if (mode == INPUT) {
+      if (mode == PIN_MODE_INPUT) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT);
       } else {
         pinMode(PIN_TO_DIGITAL(pin), INPUT_PULLUP);
@@ -110,7 +110,7 @@ boolean DigitalInputFirmata::handlePinMode(byte pin, int mode)
 void DigitalInputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    Firmata.write((byte)INPUT);
+    Firmata.write((byte)PIN_MODE_INPUT);
     Firmata.write(1);
     Firmata.write((byte)PIN_MODE_PULLUP);
     Firmata.write(1);

--- a/src/DigitalOutputFirmata.cpp
+++ b/src/DigitalOutputFirmata.cpp
@@ -35,7 +35,7 @@ void digitalOutputWriteCallback(byte port, int value)
 void handleSetPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (Firmata.getPinMode(pin) == OUTPUT) {
+    if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT) {
       digitalWrite(pin, value);
       Firmata.setPinState(pin, value);
     }
@@ -71,11 +71,11 @@ void DigitalOutputFirmata::digitalWritePort(byte port, int value)
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
         // do not touch pins in PWM, ANALOG, SERVO or other modes
-        if (Firmata.getPinMode(pin) == OUTPUT || Firmata.getPinMode(pin) == INPUT) {
+        if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT || Firmata.getPinMode(pin) == PIN_MODE_INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          if (Firmata.getPinMode(pin) == OUTPUT) {
+          if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT) {
             pinWriteMask |= mask;
-          } else if (Firmata.getPinMode(pin) == INPUT && pinValue == 1 && Firmata.getPinState(pin) != 1) {
+          } else if (Firmata.getPinMode(pin) == PIN_MODE_INPUT && pinValue == 1 && Firmata.getPinState(pin) != 1) {
             pinMode(pin, INPUT_PULLUP);
           }
           Firmata.setPinState(pin, pinValue);
@@ -89,7 +89,7 @@ void DigitalOutputFirmata::digitalWritePort(byte port, int value)
 
 boolean DigitalOutputFirmata::handlePinMode(byte pin, int mode)
 {
-  if (IS_PIN_DIGITAL(pin) && mode == OUTPUT && Firmata.getPinMode(pin) != PIN_MODE_IGNORE) {
+  if (IS_PIN_DIGITAL(pin) && mode == PIN_MODE_OUTPUT && Firmata.getPinMode(pin) != PIN_MODE_IGNORE) {
     digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable PWM
     pinMode(PIN_TO_DIGITAL(pin), OUTPUT);
     return true;
@@ -100,7 +100,7 @@ boolean DigitalOutputFirmata::handlePinMode(byte pin, int mode)
 void DigitalOutputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    Firmata.write((byte)OUTPUT);
+    Firmata.write((byte)PIN_MODE_OUTPUT);
     Firmata.write(1);
   }
 }

--- a/src/utility/Boards.h
+++ b/src/utility/Boards.h
@@ -596,6 +596,33 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         (p)
 #define DEFAULT_PWM_RESOLUTION  10
 
+// ESP32
+// Tested on Sparkfun ESP32 Thing, may work with other ESP32 boards, but not verified.
+// Pins D34 - D39 Digital Input only
+// TODO: validate if Serial2 maps to rx = 16, tx = 17
+// ESP32 boards currently only work with Firmata over Wi-Fi.
+// Supply > 500mA to the board (laptop USB current is typically not enough, use a powered USB hub).
+#elif defined(ESP32)
+#define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
+#define TOTAL_PINS              NUM_DIGITAL_PINS
+#define VERSION_BLINK_PIN       LED_BUILTIN
+// Serial0 not supported
+// #define PIN_SERIAL_RX           3
+// #define PIN_SERIAL_TX           1
+#define IS_PIN_DIGITAL(p)       ((p) < 6 || ((p) >= 12 && (p) < 24) || ((p) >= 25 && (p) < 28) || ((p) >= 32 && (p) <= 39))
+#define IS_PIN_ANALOG(p)        ((p) == 0 || (p) == 2 || (p) == 4 || ((p) >= 12 && (p) < 16) || ((p >= 25 && (p) < 28) || ((p) >= 32 && (p) < 37) || (p) == 39))
+#define IS_PIN_PWM(p)           (0) // analogWrite is not yet supported
+#define IS_PIN_SERVO(p)         (IS_PIN_DIGITAL(p) && (p) < MAX_SERVOS)
+#define IS_PIN_I2C(p)           ((p) == SDA || (p) == SCL)
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define IS_PIN_INTERRUPT(p)     (digitalPinToInterrupt(p) > NOT_AN_INTERRUPT)
+// #define IS_PIN_SERIAL(p)        ((p) == PIN_SERIAL_RX || (p) == PIN_SERIAL_TX)
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        digitalPinToAnalogChannel(p) // defined in esp32-hal-gpio.h
+#define PIN_TO_PWM(p)           PIN_TO_DIGITAL(p)
+#define PIN_TO_SERVO(p)         (p)
+#define DEFAULT_ADC_RESOLUTION  12
+
 
 // anything else
 #else
@@ -604,7 +631,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 
 // as long this is not defined for all boards:
 #ifndef IS_PIN_SPI
-#define IS_PIN_SPI(p)           (0)
+#define IS_PIN_SPI(p)           0
 #endif
 
 #ifndef IS_PIN_SERIAL
@@ -613,6 +640,10 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 
 #ifndef DEFAULT_PWM_RESOLUTION
 #define DEFAULT_PWM_RESOLUTION  8
+#endif
+
+#ifndef DEFAULT_ADC_RESOLUTION
+#define DEFAULT_ADC_RESOLUTION  10
 #endif
 
 /*==============================================================================

--- a/src/utility/WiFiStream.h
+++ b/src/utility/WiFiStream.h
@@ -69,7 +69,7 @@ public:
  *           network configuration
  ******************************************************************************/
 
-#ifndef ESP8266
+#if !defined(ESP8266) && !defined(ESP32)
   /**
    * configure a static local IP address without defining the local network
    * DHCP will be used as long as local IP address is not defined
@@ -90,7 +90,7 @@ public:
     _local_ip = local_ip;
     _subnet = subnet;
     _gateway = gateway;
-#ifndef ESP8266
+#if !defined(ESP8266)
     WiFi.config( local_ip, IPAddress(0, 0, 0, 0), gateway, subnet );
 #else
     WiFi.config( local_ip, gateway, subnet );
@@ -115,7 +115,7 @@ public:
    */
   virtual bool maintain() = 0;
 
-#ifdef ESP8266
+#if defined(ESP8266)
   /**
    * get status of TCP connection
    * @return status of TCP connection
@@ -160,7 +160,7 @@ public:
     return WiFi.status();
   }
 
-#ifndef ESP8266
+#if !defined(ESP8266) && !defined(ESP32)
   /**
    * initialize WiFi with WEP security and initiate client connection
    * if WiFi connection is already established


### PR DESCRIPTION
Wi-Fi transport only for now.
Tested on Sparkfun ESP32 Thing board.

This is sorta working when the board is configured as a TCP server (default) or client. However establishing a connection currently requires some patience. I suspect there may be issues in the ESP32 WiFi library because board locks up while trying to establish a connection with the AP more than half the time. It could also be a power issue. I've found the connection to be much more stable when using a USB power supply vs using my laptop usb port, but even with a power supply I still have to hit reset on the board a few times. I suspect a power supply > 500 mA is required (something in the 1000 to 2000 mA range is probably best).

Currently the procedure is restart the board, wait a couple of seconds then start the Firmata client application. It may take several seconds for the Firmata client to connect. Also, if reading analog pins, there are very noticeable lags. I suspect a more robust buffering scheme is necessary for Firmata to support boards like this.

I have no immediate plans to enable using ESP32 boards with Firmata using a Serial/USB transport or a BLE transport.

Firmata client examples interfacing with the ESP32 via a TCP client or server connection can be found [here](https://github.com/soundanalogous/firmata-client-examples/commit/8a943c189957b16cc3ac1f789fdd91ca367c98cd) (using firmata.js).

This branch will not be merged until WiFi connectivity and buffering is improved (could use help on figuring out an approach for the later), so checkout the esp-thing branch in the mean time.