### PR TITLE
fixed mask used for stepType

### DIFF
--- a/src/AccelStepperFirmata.cpp
+++ b/src/AccelStepperFirmata.cpp
@@ -97,7 +97,7 @@ boolean AccelStepperFirmata::handleSysex(byte command, byte argc, byte *argv)
       if (stepCommand == ACCELSTEPPER_CONFIG) {
         interface = argv[index++];
         wireCount = (interface & 0x70) >> 4; // upper 3 bits are the wire count
-        stepType = (interface & 0x07) >> 1; // bits 4-6 are the step type
+        stepType = (interface & 0x0e) >> 1; // next 3 bits are the step type
         stepOrMotorPin1 = argv[index++]; // Step pin for driver or MotorPin1
         directionOrMotorPin2 = argv[index++]; // Direction pin for driver or motorPin2
 


### PR DESCRIPTION
Version 2.6.0 of the Firmata protocol
https://github.com/firmata/protocol/blob/master/accelStepperFirmata.md
says that, during accelStepper configuration, bits 4-6 of the interface byte encode the step type. To get bits 4-6, we should AND the interface byte with a mask of 0x0e.