### PR TITLE
Implements EXTENDED_ANALOG_READ message

### DIFF
--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -30,12 +30,12 @@ void reportAnalogInputCallback(byte analogPin, int value)
 AnalogInputFirmata::AnalogInputFirmata()
 {
   AnalogInputFirmataInstance = this;
-  analogInputsToReport = 0;
+  reset();
   Firmata.attach(REPORT_ANALOG, reportAnalogInputCallback);
 }
 
 // -----------------------------------------------------------------------------
-/* sets bits in a bit array (int) to toggle the reporting of the analogIns
+/* sets bits in a byte array to toggle the reporting of the analog pins
  */
 //void FirmataClass::setAnalogPinReporting(byte pin, byte state) {
 //}
@@ -43,9 +43,11 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, int value)
 {
   if (analogPin < TOTAL_ANALOG_PINS) {
     if (value == 0) {
-      analogInputsToReport = analogInputsToReport & ~ (1 << analogPin);
+      // analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)] &=  ~ (1 << ANALOG_INPUTS_BIT_INDEX(analogPin));
+      bitClear(analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)], ANALOG_INPUTS_BIT_INDEX(analogPin));
     } else {
-      analogInputsToReport = analogInputsToReport | (1 << analogPin);
+      // analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)] |= (1 << ANALOG_INPUTS_BIT_INDEX(analogPin));
+      bitSet(analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)], ANALOG_INPUTS_BIT_INDEX(analogPin));
       // prevent during system reset or all analog pin values will be reported
       // which may report noise for unconnected analog pins
       if (!Firmata.isResetting()) {
@@ -85,13 +87,36 @@ void AnalogInputFirmata::handleCapability(byte pin)
 
 boolean AnalogInputFirmata::handleSysex(byte command, byte argc, byte* argv)
 {
+  if (command == EXTENDED_ANALOG_READ) {
+    if (argc > 0) {
+      byte subCommand = argv[0] & 0x7F;
+
+      if (subCommand == EXTENDED_ANALOG_READ_QUERY) {
+        uint8_t analogPin = argv[1];
+
+        if (argc > 2) {
+          if (argv[2]) {
+            reportAnalog(analogPin, 1);
+          } else {
+            reportAnalog(analogPin, 0);
+            // TODO: Check if message should be sent
+          }
+        } else {
+          Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
   return handleAnalogFirmataSysex(command, argc, argv);
 }
 
 void AnalogInputFirmata::reset()
 {
   // by default, do not report any analog inputs
-  analogInputsToReport = 0;
+  memset(analogInputsToReport, 0, ANALOG_INPUTS_BIT_ARRAY_SIZE);
 }
 
 void AnalogInputFirmata::report()
@@ -101,7 +126,7 @@ void AnalogInputFirmata::report()
   for (pin = 0; pin < TOTAL_PINS; pin++) {
     if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {
       analogPin = PIN_TO_ANALOG(pin);
-      if (analogInputsToReport & (1 << analogPin)) {
+      if (bitRead(analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)], ANALOG_INPUTS_BIT_INDEX(analogPin))) {
         Firmata.sendAnalog(analogPin, analogRead(analogPin));
       }
     }

--- a/src/AnalogInputFirmata.h
+++ b/src/AnalogInputFirmata.h
@@ -21,6 +21,14 @@
 #include "FirmataFeature.h"
 #include "FirmataReporting.h"
 
+extern "C" {
+#include <limits.h>
+}
+
+#define ANALOG_INPUTS_BIT_ARRAY_SIZE ((TOTAL_ANALOG_PINS / CHAR_BIT) + ((TOTAL_ANALOG_PINS % CHAR_BIT) ? 1 : 0))
+#define ANALOG_INPUTS_BYTE_INDEX(b)  (b / CHAR_BIT)
+#define ANALOG_INPUTS_BIT_INDEX(b)   (b % CHAR_BIT)
+
 void reportAnalogInputCallback(byte analogPin, int value);
 
 class AnalogInputFirmata: public FirmataFeature
@@ -36,7 +44,7 @@ class AnalogInputFirmata: public FirmataFeature
 
   private:
     /* analog inputs */
-    int analogInputsToReport; // bitwise array to store pin reporting
+    byte analogInputsToReport[ANALOG_INPUTS_BIT_ARRAY_SIZE]; // bitwise array to store pin reporting
 };
 
 #endif

--- a/src/AnalogOutputFirmata.cpp
+++ b/src/AnalogOutputFirmata.cpp
@@ -50,7 +50,7 @@ void AnalogOutputFirmata::handleCapability(byte pin)
 
 boolean AnalogOutputFirmata::handleSysex(byte command, byte argc, byte* argv)
 {
-  if (command == EXTENDED_ANALOG) {
+  if (command == EXTENDED_ANALOG_WRITE) {
     if (argc > 1) {
       int val = argv[1];
       if (argc > 2) val |= (argv[2] << 7);

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -81,7 +81,7 @@
 #define I2C_REQUEST             0x76 // send an I2C read/write request
 #define I2C_REPLY               0x77 // a reply to an I2C read request
 #define I2C_CONFIG              0x78 // config I2C settings such as delay times and power pins
-#define EXTENDED_ANALOG         0x6F // analog write (PWM, Servo, etc) to any pin
+#define EXTENDED_ANALOG_WRITE   0x6F // analog write (PWM, Servo, etc) to any pin
 #define PIN_STATE_QUERY         0x6D // ask for a pin's current mode and value
 #define PIN_STATE_RESPONSE      0x6E // reply with pin's current mode and value
 #define CAPABILITY_QUERY        0x6B // ask for supported modes and resolution of all pins

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -81,6 +81,7 @@
 #define I2C_REQUEST             0x76 // send an I2C read/write request
 #define I2C_REPLY               0x77 // a reply to an I2C read request
 #define I2C_CONFIG              0x78 // config I2C settings such as delay times and power pins
+#define EXTENDED_ANALOG_READ    0x66 // single read from analog pin with extended options
 #define EXTENDED_ANALOG_WRITE   0x6F // analog write (PWM, Servo, etc) to any pin
 #define PIN_STATE_QUERY         0x6D // ask for a pin's current mode and value
 #define PIN_STATE_RESPONSE      0x6E // reply with pin's current mode and value
@@ -93,6 +94,10 @@
 #define SCHEDULER_DATA          0x7B // send a createtask/deletetask/addtotask/schedule/querytasks/querytask request to the scheduler
 #define SYSEX_NON_REALTIME      0x7E // MIDI Reserved for non-realtime messages
 #define SYSEX_REALTIME          0x7F // MIDI Reserved for realtime messages
+
+// EXTENDED_ANALOG_READ commmands
+#define EXTENDED_ANALOG_READ_QUERY 0x00
+#define EXTENDED_ANALOG_READ_RESPONSE 0x01
 
 // these are DEPRECATED to make the naming more consistent
 #define FIRMATA_STRING          0x71 // same as STRING_DATA
@@ -184,6 +189,7 @@ class FirmataClass
 
     /* utility methods */
     void sendValueAsTwo7bitBytes(int value);
+    void sendValueAs7bitBytes(int value, uint8_t minBytes = 0);
     void startSysex(void);
     void endSysex(void);
 

--- a/src/FirmataExt.cpp
+++ b/src/FirmataExt.cpp
@@ -30,8 +30,10 @@ void handleSetPinModeCallback(byte pin, int mode)
 
 void handleSysexCallback(byte command, byte argc, byte* argv)
 {
+  char msg[30];
   if (!FirmataExtInstance->handleSysex(command, argc, argv)) {
-    Firmata.sendString("Unhandled sysex command");
+    sprintf(msg, "Unhandled sysex command %x", command);
+    Firmata.sendString(msg);
   }
 }
 


### PR DESCRIPTION
As discussed on https://github.com/firmata/protocol/issues/103, this implements the EXTENDED_ANALOG_READ message:

```
// The client must request an analog read, then the client will respond
0  START_SYSEX              (0xF0)
1  EXTENDED_ANALOG_READ     (0x66)
2  QUERY                    (0x00)
3  pin                      (0-127)
4  END_SYSEX                (0xF7)

// In order to report analog values for pin number > 15 and/or values > 14 bits
0  START_SYSEX              (0xF0)
1  EXTENDED_ANALOG_READ     (0x66)
2  RESPONSE                 (0x01)
3  pin                      (0-127)
4  bits 0-6                 [optional] (least significant byte - not sent if value is 0)
5  bits 7-13                [optional] (most significant byte - not sent if all bits are the same as bit 6)
... additional bytes may be sent if more bits are needed (could limit this to 32 bits)
N  END_SYSEX                (0xF7)
```

The bytes containing the value won't be sent if the value is 0 or if the MSB bytes have only the same bit as the higher bit on the previous byte. This way, both signed and unsigned values can be reconstructed without having to send all the bits of the original value. When receiving, the host needs to fill all the left-most bits not received with the value from the most significant bit received.

Here's an example in JS:

```
for (var i = 0; i < numberBuffer.length; i++) {
  value = value | ((numberBuffer[i] & 0x7F) << (i * 7));
}
if (numberBuffer[numberBuffer.length - 1] & 0b01000000) {
  // Last higher bit is 1, so fill the remaining bits with 1's
  value = value | (-1 << (7 * numberBuffer.length));
}
```

I left the `// analogInputsToReport[ANALOG_INPUTS_BYTE_INDEX(analogPin)] &=  ~ (1 << ANALOG_INPUTS_BIT_INDEX(analogPin));` comments for reference as I prefer the bit set functions, but either way is working fine, let me know your preference.