### PR TITLE
Change example sketches to avoid spurious analog reports on setup.

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -374,7 +374,7 @@ void setup()
   // start up the default Firmata using Serial interface:
   Firmata.begin(57600);
 #endif
-  systemResetCallback();  // reset to default config
+  Firmata.parse(SYSTEM_RESET);  // reset to default config
 }
 
 /*==============================================================================

--- a/examples/ConfigurableFirmataBLE/ConfigurableFirmataBLE.ino
+++ b/examples/ConfigurableFirmataBLE/ConfigurableFirmataBLE.ino
@@ -314,7 +314,7 @@ firmataExt.addFeature(accelStepper);
 
   // Initialize Firmata to use the BLE stream object as the transport.
   Firmata.begin(stream);
-  systemResetCallback();  // reset to default config
+  Firmata.parse(SYSTEM_RESET);  // reset to default config
 }
 
 void setup()

--- a/examples/ConfigurableFirmataWiFi/ConfigurableFirmataWiFi.ino
+++ b/examples/ConfigurableFirmataWiFi/ConfigurableFirmataWiFi.ino
@@ -615,7 +615,7 @@ firmataExt.addFeature(accelStepper);
 
   // Initialize Firmata to use the WiFi stream object as the transport.
   Firmata.begin(stream);
-  systemResetCallback();  // reset to default config
+  Firmata.parse(SYSTEM_RESET);  // reset to default config
 }
 
 


### PR DESCRIPTION
As discussed in #81, this prevents spurious analog pin reporting behavior at the end of setup. I was able to run two basic tests of the example sketch on an Arduino Uno:

- I ran the blink script discussed in the initial report in #81 and confirmed successful execution of the script.
- I ran a blink program implemented in Snap4Arduino (running on a ChromeOS environment) and confirmed successful connection of the Arduino board and execution of the program.