### PR TITLE
Return only as many bytes as the hardware returned

### DIFF
--- a/src/I2CFirmata.h
+++ b/src/I2CFirmata.h
@@ -111,6 +111,7 @@ void I2CFirmata::readAndReportData(byte address, int theRegister, byte numBytes,
     Firmata.sendString("I2C: Too many bytes received");
   } else if (numBytes > Wire.available()) {
     Firmata.sendString("I2C: Too few bytes received");
+    numBytes = Wire.available();
   }
 
   i2cRxData[0] = address;


### PR DESCRIPTION
This small patch fixes https://github.com/firmata/arduino/issues/444. Instead of returning a buffeer with fewer (or no) valid data than expected, we're only returning as many bytes as there actually were. 
Most clients should not be affected by this, because if the hardware is properly working, this should not happen. However it enables the possibility to use ReadByte() commands to poll for valid I2C addresses, making the equivalent of I2Cdetect work over firmata. 