### PR TITLE
Save some memory

### DIFF
--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -491,6 +491,21 @@ void FirmataClass::sendString(const char *string)
 }
 
 /**
+ * Send a constant string to the Firmata host application.
+ * @param string A pointer to the string in flash memory
+ */
+void FirmataClass::sendString(const __FlashStringHelper* flashString)
+{
+  int len = strlen_P((const char*)flashString);
+  startSysex();
+  FirmataStream->write(STRING_DATA);
+  for (int i = 0; i < len; i++) {
+    sendValueAsTwo7bitBytes(pgm_read_byte(((const char*)flashString) + i));
+  }
+  endSysex();
+}
+
+/**
  * A wrapper for Stream::available().
  * Write a single byte to the output stream.
  * @param c The byte to be written.

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -162,6 +162,7 @@ class FirmataClass
     void sendAnalog(byte pin, int value);
     void sendDigital(byte pin, int value); // TODO implement this
     void sendDigitalPort(byte portNumber, int portData);
+    void sendString(const __FlashStringHelper* flashString);
     void sendString(const char *string);
     void sendString(byte command, const char *string);
     void sendSysex(byte command, byte bytec, byte *bytev);

--- a/src/FirmataExt.cpp
+++ b/src/FirmataExt.cpp
@@ -24,14 +24,14 @@ FirmataExt *FirmataExtInstance;
 void handleSetPinModeCallback(byte pin, int mode)
 {
   if (!FirmataExtInstance->handlePinMode(pin, mode) && mode != PIN_MODE_IGNORE) {
-    Firmata.sendString("Unknown pin mode"); // TODO: put error msgs in EEPROM
+    Firmata.sendString(F("Unknown pin mode")); 
   }
 }
 
 void handleSysexCallback(byte command, byte argc, byte* argv)
 {
   if (!FirmataExtInstance->handleSysex(command, argc, argv)) {
-    Firmata.sendString("Unhandled sysex command");
+    Firmata.sendString(F("Unhandled sysex command"));
   }
 }
 

--- a/src/I2CFirmata.h
+++ b/src/I2CFirmata.h
@@ -108,9 +108,9 @@ void I2CFirmata::readAndReportData(byte address, int theRegister, byte numBytes,
 
   // check to be sure correct number of bytes were returned by slave
   if (numBytes < Wire.available()) {
-    Firmata.sendString("I2C: Too many bytes received");
+    Firmata.sendString(F("I2C: Too many bytes received"));
   } else if (numBytes > Wire.available()) {
-    Firmata.sendString("I2C: Too few bytes received");
+    Firmata.sendString(F("I2C: Too few bytes received"));
     numBytes = Wire.available();
   }
 
@@ -173,7 +173,7 @@ void I2CFirmata::handleI2CRequest(byte argc, byte *argv)
   int slaveRegister;
   mode = argv[1] & I2C_READ_WRITE_MODE_MASK;
   if (argv[1] & I2C_10BIT_ADDRESS_MODE_MASK) {
-    Firmata.sendString("10-bit addressing not supported");
+    Firmata.sendString(F("10-bit addressing not supported"));
     return;
   }
   else {
@@ -215,7 +215,7 @@ void I2CFirmata::handleI2CRequest(byte argc, byte *argv)
     case I2C_READ_CONTINUOUSLY:
       if ((queryIndex + 1) >= I2C_MAX_QUERIES) {
         // too many queries, just ignore
-        Firmata.sendString("too many queries");
+        Firmata.sendString(F("too many queries"));
         break;
       }
       if (argc == 6) {

--- a/src/SerialFirmata.cpp
+++ b/src/SerialFirmata.cpp
@@ -90,7 +90,7 @@ boolean SerialFirmata::handleSysex(byte command, byte argc, byte *argv)
               swTxPin = argv[5];
             } else {
               // RX and TX pins must be specified when using software serial
-              Firmata.sendString("Specify serial RX and TX pins");
+              Firmata.sendString(F("Specify serial RX and TX pins"));
               return false;
             }
             switch (portId) {


### PR DESCRIPTION
This saves some RAM by directly reading error messages from Flash memory instead of from RAM. 
Also removed an unused member in the OneWire implementation that reserved 8 bytes * NUMBER_OF_PINS ram for nothing. 