### PR TITLE
Add support for ESP32/Arduino

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -4,9 +4,19 @@
 
 #include <ConfigurableFirmata.h>
 
+// Use this to enable WIFI instead of serial communication. Tested on ESP32, but should also
+// work with Wifi-enabled Arduinos
+// #define ENABLE_WIFI
+
+const char* ssid     = "your-ssid";
+const char* password = "your-password";
+const int NETWORK_PORT = 27016;
+
 // Use these defines to easily enable or disable certain modules
 
 #define ENABLE_ONE_WIRE
+
+// Note that the SERVO module currently is not supported on ESP32. So either disable this or patch the library
 #define ENABLE_SERVO 
 #define ENABLE_ACCELSTEPPER
 #define ENABLE_BASIC_SCHEDULER
@@ -32,6 +42,14 @@ AnalogInputFirmata analogInput;
 #include <AnalogOutputFirmata.h>
 AnalogOutputFirmata analogOutput;
 #include <AnalogWrite.h>
+#endif
+
+
+#ifdef ENABLE_WIFI
+#include <WiFi.h>
+#include "utility/WiFiClientStream.h"
+#include "utility/WiFiServerStream.h"
+WiFiServerStream serverStream(NETWORK_PORT);
 #endif
 
 #ifdef ENABLE_I2C
@@ -86,7 +104,7 @@ void systemResetCallback()
     if (IS_PIN_ANALOG(i)) {
       Firmata.setPinMode(i, PIN_MODE_ANALOG);
     } else if (IS_PIN_DIGITAL(i)) {
-      Firmata.setPinMode(i, OUTPUT);
+      Firmata.setPinMode(i, PIN_MODE_OUTPUT);
     }
   }
   firmataExt.reset();
@@ -96,7 +114,23 @@ void initTransport()
 {
   // Uncomment to save a couple of seconds by disabling the startup blink sequence.
   // Firmata.disableBlinkVersion();
-    Firmata.begin(115200);
+#ifdef ENABLE_WIFI
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  pinMode(VERSION_BLINK_PIN, OUTPUT);
+  bool pinIsOn = false;
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    delay(100);
+    pinIsOn = !pinIsOn;
+    digitalWrite(VERSION_BLINK_PIN, pinIsOn);
+  }
+  Firmata.begin(serverStream);
+  Firmata.blinkVersion(); // Because the above doesn't do it.
+#else 
+  Firmata.begin(115200);
+#endif
+    
 }
 
 void initFirmata()
@@ -173,4 +207,7 @@ void loop()
   }
 
   firmataExt.report(reporting.elapsed());
+#ifdef ENABLE_WIFI
+  serverStream.maintain();
+#endif
 }

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -99,8 +99,9 @@
 #define SYSEX_SAMPLING_INTERVAL 0x7A // same as SAMPLING_INTERVAL
 
 // pin modes
-#define PIN_MODE_INPUT          0x00 // defined in Arduino.h
-#define PIN_MODE_OUTPUT         0x01 // defined in Arduino.h
+#define PIN_MODE_INPUT          0x00 // INPUT is defined in Arduino.h, but may conflict with other uses
+#define PIN_MODE_OUTPUT         0x01 // OUTPUT is defined in Arduino.h. Careful: OUTPUT is defined as 2 on ESP32!
+                                     // therefore OUTPUT and PIN_MODE_OUTPUT are not the same!
 #define PIN_MODE_ANALOG         0x02 // analog pin in analogInput mode
 #define PIN_MODE_PWM            0x03 // digital pin in PWM output mode
 #define PIN_MODE_SERVO          0x04 // digital pin in Servo output mode
@@ -145,7 +146,7 @@ class FirmataClass
     /* serial receive handling */
     int available(void);
     void processInput(void);
-    void parse(unsigned char value);
+    void parse(byte inputData);
     boolean isParsingMessage(void);
     boolean isResetting(void);
     /* serial send handling */

--- a/src/DigitalInputFirmata.cpp
+++ b/src/DigitalInputFirmata.cpp
@@ -97,10 +97,10 @@ void DigitalInputFirmata::reportDigital(byte port, int value)
 boolean DigitalInputFirmata::handlePinMode(byte pin, int mode)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    if (mode == INPUT || mode == PIN_MODE_PULLUP) {
+    if (mode == PIN_MODE_INPUT || mode == PIN_MODE_PULLUP) {
       portConfigInputs[pin / 8] |= (1 << (pin & 7));
-      if (mode == INPUT) {
-        pinMode(PIN_TO_DIGITAL(pin), INPUT);
+      if (mode == PIN_MODE_INPUT) {
+        pinMode(PIN_TO_DIGITAL(pin), PIN_MODE_INPUT);
       } else {
         pinMode(PIN_TO_DIGITAL(pin), INPUT_PULLUP);
         Firmata.setPinState(pin, 1);
@@ -116,10 +116,10 @@ boolean DigitalInputFirmata::handlePinMode(byte pin, int mode)
 void DigitalInputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    Firmata.write((byte)INPUT);
-    Firmata.write(1);
+    Firmata.write((byte)PIN_MODE_INPUT);
+    Firmata.write((byte)1);
     Firmata.write((byte)PIN_MODE_PULLUP);
-    Firmata.write(1);
+    Firmata.write((byte)1);
   }
 }
 

--- a/src/DigitalOutputFirmata.cpp
+++ b/src/DigitalOutputFirmata.cpp
@@ -35,7 +35,7 @@ void digitalOutputWriteCallback(byte port, int value)
 void handleSetPinValueCallback(byte pin, int value)
 {
   if (pin < TOTAL_PINS && IS_PIN_DIGITAL(pin)) {
-    if (Firmata.getPinMode(pin) == OUTPUT) {
+    if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT) {
       digitalWrite(pin, value);
       Firmata.setPinState(pin, value);
     }
@@ -71,9 +71,9 @@ void DigitalOutputFirmata::digitalWritePort(byte port, int value)
       // do not disturb non-digital pins (eg, Rx & Tx)
       if (IS_PIN_DIGITAL(pin)) {
         // do not touch pins in PWM, ANALOG, SERVO or other modes
-        if (Firmata.getPinMode(pin) == OUTPUT || Firmata.getPinMode(pin) == INPUT) {
+        if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT || Firmata.getPinMode(pin) == INPUT) {
           pinValue = ((byte)value & mask) ? 1 : 0;
-          if (Firmata.getPinMode(pin) == OUTPUT) {
+          if (Firmata.getPinMode(pin) == PIN_MODE_OUTPUT) {
             pinWriteMask |= mask;
           } else if (Firmata.getPinMode(pin) == INPUT && pinValue == 1 && Firmata.getPinState(pin) != 1) {
             pinMode(pin, INPUT_PULLUP);
@@ -89,7 +89,7 @@ void DigitalOutputFirmata::digitalWritePort(byte port, int value)
 
 boolean DigitalOutputFirmata::handlePinMode(byte pin, int mode)
 {
-  if (IS_PIN_DIGITAL(pin) && mode == OUTPUT && Firmata.getPinMode(pin) != PIN_MODE_IGNORE) {
+  if (IS_PIN_DIGITAL(pin) && mode == PIN_MODE_OUTPUT && Firmata.getPinMode(pin) != PIN_MODE_IGNORE) {
     digitalWrite(PIN_TO_DIGITAL(pin), LOW); // disable PWM
     pinMode(PIN_TO_DIGITAL(pin), OUTPUT);
     return true;
@@ -100,7 +100,7 @@ boolean DigitalOutputFirmata::handlePinMode(byte pin, int mode)
 void DigitalOutputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_DIGITAL(pin)) {
-    Firmata.write((byte)OUTPUT);
-    Firmata.write(1);
+    Firmata.write((byte)PIN_MODE_OUTPUT);
+    Firmata.write((byte)1);
   }
 }

--- a/src/utility/Boards.h
+++ b/src/utility/Boards.h
@@ -681,6 +681,35 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_SERVO(p)         (p)
 #define DEFAULT_PWM_RESOLUTION  PWM_RESOLUTION
 
+// ESP32
+#elif defined(ESP32)
+#define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
+#define TOTAL_PINS              NUM_DIGITAL_PINS
+#define VERSION_BLINK_PIN       2
+#define digitalPinHasSPI(p)     ((p) == 12 || (p) == 13 || (p) == 14 || (p) == 15)
+#define PIN_SPI_MOSI            13
+#define PIN_SPI_MISO            12
+#define PIN_SPI_SCK             14
+#define digitalPinHasSerial(p)  ((p) == 16 || (p) == 17 || (p) == 1 || (p) == 3)
+// Pins 1 and 3 are used for the USB Serial communication. If we enable them here, the initial pin reset causes the serial communication
+// to not work after boot. 
+#define IS_PIN_DIGITAL(p)       ((p) == 0 || (p) == 2 || (p) == 4 || ((p) >= 12 && (p) < 24) || ((p) >= 25 && (p) < 28) || ((p) >= 32 && (p) <= 39))
+#define IS_PIN_ANALOG(p)        ((p) == 0 || (p) == 2 || (p) == 4 || ((p) >= 12 && (p) < 16) || ((p >= 25 && (p) < 28) || ((p) >= 32 && (p) < 37) || (p) == 39))
+#define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p) && digitalPinHasPWM(p))
+#define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
+#define IS_PIN_I2C(p)           (IS_PIN_DIGITAL(p) && (p == 21) || (p == 22) )
+#define IS_PIN_SPI(p)           (IS_PIN_DIGITAL(p) && digitalPinHasSPI(p))
+#define IS_PIN_INTERRUPT(p)     (digitalPinToInterrupt(p) > NOT_AN_INTERRUPT)
+#define IS_PIN_SERIAL(p)        (digitalPinHasSerial(p))
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        digitalPinToAnalogChannel(p) // defined in esp32-hal-gpio.h
+#define PIN_TO_PWM(p)           (p)
+#define PIN_TO_SERVO(p)         (p)
+#define DEFAULT_PWM_RESOLUTION  8
+#define DEFAULT_ADC_RESOLUTION  12
+
+// Defined in AnalogOutputFirmata.cpp
+void analogWrite(uint8_t channel, uint32_t value, uint32_t valueMax = 255);
 
 // Adafruit Bluefruit nRF52 boards
 #elif defined(ARDUINO_NRF52_ADAFRUIT)

--- a/src/utility/WiFiStream.h
+++ b/src/utility/WiFiStream.h
@@ -69,7 +69,7 @@ public:
  *           network configuration
  ******************************************************************************/
 
-#ifndef ESP8266
+#if !ESP8266 && !ESP32
   /**
    * configure a static local IP address without defining the local network
    * DHCP will be used as long as local IP address is not defined
@@ -160,7 +160,7 @@ public:
     return WiFi.status();
   }
 
-#ifndef ESP8266
+#if !ESP8266 && !ESP32
   /**
    * initialize WiFi with WEP security and initiate client connection
    * if WiFi connection is already established


### PR DESCRIPTION
Requires the Arduino toolkit for ESP32, https://github.com/espressif/arduino-esp32.
See there for installation instructions.

Includes support for accessing the ESP32 via WIFI. 