### PR TITLE
Add DHT support

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -19,12 +19,15 @@ const int NETWORK_PORT = 27016;
 // Note that the SERVO module currently is not supported on ESP32. So either disable this or patch the library
 #define ENABLE_SERVO 
 #define ENABLE_ACCELSTEPPER
-#define ENABLE_BASIC_SCHEDULER
+
+// This is rarely used
+// #define ENABLE_BASIC_SCHEDULER
 #define ENABLE_SERIAL
 #define ENABLE_I2C
 #define ENABLE_SPI
 #define ENABLE_ANALOG
 #define ENABLE_DIGITAL
+#define ENABLE_DHT
 
 
 #ifdef ENABLE_DIGITAL
@@ -72,6 +75,11 @@ OneWireFirmata oneWire;
 #ifdef ENABLE_SERIAL
 #include <SerialFirmata.h>
 SerialFirmata serial;
+#endif
+
+#ifdef ENABLE_DHT
+#include <DhtFirmata.h>
+DhtFirmata dhtFirmata;
 #endif
 
 #include <FirmataExt.h>

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -29,8 +29,8 @@ extern "C" {
 //******************************************************************************
 
 /**
- * Split a 16-bit byte into two 7-bit values and write each value.
- * @param value The 16-bit value to be split and written separately.
+ * Split a 14-bit byte into two 7-bit values and write each value.
+ * @param value The 14-bit value to be split and written separately.
  */
 void FirmataClass::sendValueAsTwo7bitBytes(int value)
 {

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -67,6 +67,7 @@
 #define STRING_DATA             0x71 // a string message with 14-bits per char
 #define STEPPER_DATA            0x72 // control a stepper motor
 #define ONEWIRE_DATA            0x73 // send an OneWire read/write/reset/select/skip/search request
+#define DHTSENSOR_DATA          0x74 // Used by DhtFirmata
 #define SHIFT_DATA              0x75 // a bitstream to/from a shift register
 #define I2C_REQUEST             0x76 // send an I2C read/write request
 #define I2C_REPLY               0x77 // a reply to an I2C read request
@@ -112,7 +113,12 @@
 #define PIN_MODE_ENCODER        0x09 // pin configured for rotary encoders
 #define PIN_MODE_SERIAL         0x0A // pin configured for serial communication
 #define PIN_MODE_PULLUP         0x0B // enable internal pull-up resistor for pin
+// Extensions under development
 #define PIN_MODE_SPI            0x0C // pin configured for SPI
+#define PIN_MODE_SONAR =        0x0D // pin configured for HC-SR04
+#define PIN_MODE_TONE =         0x0E // pin configured for tone
+#define PIN_MODE_DHT            0x0F // pin configured for DHT
+
 #define PIN_MODE_IGNORE         0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
 #define TOTAL_PIN_MODES         16
 

--- a/src/DhtFirmata.cpp
+++ b/src/DhtFirmata.cpp
@@ -1,0 +1,3 @@
+/*
+ * Implementation is in DhtFirmata.h
+ */

--- a/src/DhtFirmata.h
+++ b/src/DhtFirmata.h
@@ -1,0 +1,163 @@
+/*
+  DhtFirmata.h - Firmata library
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+*/
+
+#ifndef DhtFirmata_h
+#define DhtFirmata_h
+
+#include <ConfigurableFirmata.h>
+
+#include "FirmataFeature.h"
+#include "FirmataReporting.h"
+
+#define DHTSENSOR_RESPONSE (0)
+#define DHTSENSOR_ATTACH_DHT11 (0x01)
+#define DHTSENSOR_ATTACH_DHT22 (0x02)
+#define DHTSENSOR_DETACH (0x03)
+
+#include <DHT.h>
+
+class DhtFirmata: public FirmataFeature
+{
+  public:
+    DhtFirmata();
+    boolean handlePinMode(byte pin, int mode);
+    void handleCapability(byte pin);
+    boolean handleSysex(byte command, byte argc, byte* argv);
+    void reset();
+    void report();
+
+  private:
+    void performDhtTransfer(byte command, byte argc, byte *argv);
+    void disableDht();
+    bool _isDhtEnabled;
+    int _dhtPin; // Only one sensor supported
+    DHT* _dht;
+};
+
+
+DhtFirmata::DhtFirmata()
+{
+  _isDhtEnabled = false;
+  _dhtPin = -1;
+}
+
+boolean DhtFirmata::handlePinMode(byte pin, int mode)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    if (mode == PIN_MODE_DHT) {
+      return true;
+    }
+	else if (_isDhtEnabled) 
+	{
+		disableDht();
+	}
+  }
+  return false;
+}
+
+void DhtFirmata::handleCapability(byte pin)
+{
+  if (IS_PIN_DIGITAL(pin)) {
+    Firmata.write(PIN_MODE_DHT);
+    Firmata.write(64); // 2x 32 Bit data per measurement
+  }
+}
+
+boolean DhtFirmata::handleSysex(byte command, byte argc, byte *argv)
+{
+  switch (command) {
+    case DHTSENSOR_DATA:
+		  if (argc < 2)
+		  {
+			  Firmata.sendString(F("Error in DHT command: Not enough parameters"));
+			  return false;
+		  }
+        performDhtTransfer(argv[0], argc - 1, argv + 1);
+        return true;
+
+  }
+  return false;
+}
+
+void DhtFirmata::performDhtTransfer(byte command, byte argc, byte *argv)
+{
+	if (command == DHTSENSOR_DETACH)
+	{
+		disableDht();
+		return;
+	}
+	// command byte: DHT Type
+	byte dhtType = command;
+	// The proposed protocol specification https://github.com/firmata/protocol/pull/106/commits/9389c89d3d7998dc2bd703f8c796e6a7c03f2551
+	// allows these values, too.
+	if (dhtType == 0x01)
+	{
+		dhtType = 11;
+	}
+	else if (dhtType == 0x02)
+	{
+		dhtType = 22;
+	}
+	
+	// first byte: pin
+	byte pin = argv[0];
+	if (!_isDhtEnabled)
+	{
+		_dhtPin = pin;
+		_isDhtEnabled = true;
+		_dht = new DHT(pin, dhtType);
+		_dht->begin();
+	}
+	else if (_dhtPin != pin)
+	{
+		// Switching the pin unfortunately requires re-loading the DHT class
+		delete _dht;
+		_dht = nullptr;
+		_dht = new DHT(pin, dhtType);
+		_dht->begin();
+	}
+	
+	// Accuracy of the sensor is very limited, only 8 bit humidity and maybe 10 bit for temperature
+	short humidity = (short)_dht->readHumidity() * 10;
+	short temperature = (short)(_dht->readTemperature() * 10);
+	
+	Firmata.startSysex();
+	Firmata.write(DHTSENSOR_DATA);
+	Firmata.write(DHTSENSOR_RESPONSE);
+	Firmata.write(pin);
+	Firmata.write(temperature & 0x7f);
+	Firmata.write((temperature >> 7) & 0x7f);
+	
+	Firmata.write(humidity & 0x7f);
+	Firmata.write((humidity >> 7) & 0x7f);
+	Firmata.endSysex();
+}
+
+void DhtFirmata::disableDht()
+{
+	delete _dht;
+	_dht = NULL;
+	_isDhtEnabled = false;
+}
+
+void DhtFirmata::reset()
+{
+  if (_isDhtEnabled) {
+	disableDht();
+  }
+}
+
+void DhtFirmata::report()
+{
+}
+
+#endif 


### PR DESCRIPTION
Add basic support for DHT11 and DHT22 sensors, using the "DHT Sensor Library" as backend. The implementation does not currently support periodic reporting, since with a minimum time between updates of 2500ms, polling is not an issue. 