### PR TITLE
ESP32 PWM supported on up to 16 pins at once

### DIFF
--- a/BoardSupport.md
+++ b/BoardSupport.md
@@ -36,6 +36,22 @@ Official pinout diagram is here: https://content.arduino.cc/assets/Pinout-Due_la
 | I2C, Bus 1 | Not currently supported by ConfigurableFirmata |
 | SPI, Bus 0 | Pin 77 CS (This pin is not accessible), Pin 75 MOSI, Pin 74 MISO, Pin 76 SCK (the latter three are on the SPI header, just next to the microcontroller). For CS, you have to use a GPIO pin |
 
+## ESP32
+
+The ESP32 (available in different variants) is one of the most powerful microcontrollers available. Development boards are significantly cheaper than all types of Arduino boards, so it's the most price-effective choice currently available, if you do not need the large number of pins of an Arduino Due or an Arduino Mega. 
+
+Pinout diagrams differ by vendor. The ESP32 module is almost always sold with a carrier board, because the raw module does not come with pins and is very small. 
+
+| Property  | Value |
+| ----------- | ------------------------------------ |
+| Number of Pins  | 40 total, 26 typically available for user programs
+| Number of analog inputs | 15 |
+| Flash Memory | 4MB default, variants with more are available |
+| RAM | 320kb or more|
+| PWM capable pins | All, 16 Pins can use PWM at once |
+| Built-in LED | Usually pin 2, but not always present |
+| I2C, Bus 0 | Pins 21 and 22|
+| SPI, Bus 0 | Pins 18, 19 and 23 |
 
 ## RP2040 / Raspberry Pi Pico
 

--- a/src/AnalogOutputFirmata.cpp
+++ b/src/AnalogOutputFirmata.cpp
@@ -20,50 +20,31 @@
 #include "AnalogFirmata.h"
 #include "AnalogOutputFirmata.h"
 
+#ifndef ESP32
+
 AnalogOutputFirmata::AnalogOutputFirmata()
 {
-  Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
+    Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
 }
 
 void AnalogOutputFirmata::reset()
 {
-
 }
 
-#ifdef ESP32
 
-#define LEDC_BASE_FREQ 5000
-// Arduino like analogWrite
-// value has to be between 0 and valueMax
-void analogWrite(uint8_t channel, uint32_t value, uint32_t valueMax) {
-  // calculate duty, 8191 from 2 ^ 13 - 1
-  uint32_t duty = (8191 / valueMax) * min(value, valueMax);
-
-  // write duty to LEDC
-  ledcWrite(channel, duty);
-}
-
-void setupPwmPin(byte pin) {
-  // Setup timer and attach timer to a led pin
-  ledcSetup(pin, LEDC_BASE_FREQ, 13);
-  ledcAttachPin(PIN_TO_PWM(pin), pin);
-  analogWrite(PIN_TO_PWM(pin), 0);
-}
-#else
-void setupPwmPin(byte pin)
+void AnalogOutputFirmata::setupPwmPin(byte pin)
 {
     pinMode(PIN_TO_PWM(pin), OUTPUT);
     analogWrite(PIN_TO_PWM(pin), 0);
 }
-#endif
 
 boolean AnalogOutputFirmata::handlePinMode(byte pin, int mode)
 {
-  if (mode == PIN_MODE_PWM && IS_PIN_PWM(pin)) {
-    setupPwmPin(pin);
-    return true;
-  }
-  return false;
+    if (mode == PIN_MODE_PWM && IS_PIN_PWM(pin)) {
+        setupPwmPin(pin);
+        return true;
+    }
+    return false;
 }
 
 void AnalogOutputFirmata::handleCapability(byte pin)
@@ -89,3 +70,5 @@ boolean AnalogOutputFirmata::handleSysex(byte command, byte argc, byte* argv)
     return handleAnalogFirmataSysex(command, argc, argv);
   }
 }
+
+#endif /* NOT ESP32 */

--- a/src/AnalogOutputFirmata.h
+++ b/src/AnalogOutputFirmata.h
@@ -26,6 +26,7 @@ void analogWriteCallback(byte pin, int value);
 
 class AnalogOutputFirmata: public FirmataFeature
 {
+    friend void analogWrite(byte pin, uint32_t value);
   public:
     AnalogOutputFirmata();
     void handleCapability(byte pin);
@@ -33,6 +34,14 @@ class AnalogOutputFirmata: public FirmataFeature
     boolean handleSysex(byte command, byte argc, byte* argv);
     void reset();
   private:
+      void setupPwmPin(byte pin);
+#if ESP32
+      int getChannelForPin(byte pin);
+      void internalReset();
+      void analogWriteEsp32(byte pin, uint32_t value);
+      // This gives the active pin for each pwm channel. -1 if unused
+    byte _pwmChannelMap[16];
+#endif
 };
 
 #endif

--- a/src/AnalogOutputFirmataEsp32.cpp
+++ b/src/AnalogOutputFirmataEsp32.cpp
@@ -1,0 +1,163 @@
+/*
+  AnalogFirmata.h - Firmata library
+  Copyright (C) 2006-2008 Hans-Christoph Steiner.  All rights reserved.
+  Copyright (C) 2010-2011 Paul Stoffregen.  All rights reserved.
+  Copyright (C) 2009 Shigeru Kobayashi.  All rights reserved.
+  Copyright (C) 2013 Norbert Truchsess. All rights reserved.
+  Copyright (C) 2009-2015 Jeff Hoefs.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  See file LICENSE.txt for further informations on licensing terms.
+
+  Last updated December 23rd, 2016
+*/
+
+#include <ConfigurableFirmata.h>
+#include "AnalogFirmata.h"
+#include "AnalogOutputFirmata.h"
+
+#ifdef ESP32
+
+#define LEDC_BASE_FREQ 5000
+#define MAX_PWM_CHANNELS 16
+
+AnalogOutputFirmata* AnalogOutputFirmataInstance;
+
+AnalogOutputFirmata::AnalogOutputFirmata()
+{
+    AnalogOutputFirmataInstance = this;
+    Firmata.attach(ANALOG_MESSAGE, analogWriteCallback);
+    for (int i = 0; i < MAX_PWM_CHANNELS; i++)
+    {
+        _pwmChannelMap[i] = 255;
+    }
+}
+
+void AnalogOutputFirmata::reset()
+{
+    internalReset();
+}
+
+
+// Arduino like analogWrite
+// value has to be between 0 and DEFAULT_PWM_RESOLUTION
+
+// Because we use a global redirect with the analogWriteCallback, we need to get back to the instance again using a global variable
+void analogWrite(byte channel, uint32_t value)
+{
+    AnalogOutputFirmataInstance->analogWriteEsp32(channel, value);
+}
+
+void AnalogOutputFirmata::analogWriteEsp32(uint8_t pin, uint32_t value) {
+    // calculate duty, 8191 from 2 ^ 13 - 1
+    uint32_t valueMax = (1 << DEFAULT_PWM_RESOLUTION) - 1;
+    // Firmata.sendStringf(F("Setting duty cycle to %d/%d"), 4, value, valueMax);
+    uint32_t duty = min(value, valueMax);
+    // write duty to matching channel number
+    int channel = getChannelForPin(pin);
+    if (channel != 255)
+    {
+        ledcWrite(channel, duty);
+        // Firmata.sendStringf(F("Channel %d has duty %d/%d"), 12, channel, duty, valueMax);
+    }
+}
+
+int AnalogOutputFirmata::getChannelForPin(byte pin)
+{
+    for (int i = 0; i < MAX_PWM_CHANNELS; i++)
+    {
+        if (_pwmChannelMap[i] == pin)
+        {
+            return i;
+        }
+    }
+
+    return 255;
+}
+
+void AnalogOutputFirmata::setupPwmPin(byte pin) {
+  // Setup timer and attach timer to a led pin
+    int channel = getChannelForPin(pin);
+    if (channel == 255) // pin already assigned to a channel?
+    {
+        int i;
+        for (i = 0; i < MAX_PWM_CHANNELS; i++)
+        {
+            if (_pwmChannelMap[i] == 255)
+            {
+                channel = i;
+                break;
+            }
+        }
+
+        if (i >= MAX_PWM_CHANNELS)
+        {
+            Firmata.sendStringf(F("Unable to setup pin %d for PWM - no more channels."), 4, pin);
+            return;
+        }
+    }
+
+    // Firmata.sendStringf(F("Channel %d mapped to pin %d"), 4, channel, pin);
+    _pwmChannelMap[channel] = pin;
+    pinMode(pin, OUTPUT);
+    ledcSetup(channel, LEDC_BASE_FREQ, DEFAULT_PWM_RESOLUTION); // 13 is the resolution here
+    ledcAttachPin(pin, channel);
+    analogWrite(pin, 0);
+}
+
+void AnalogOutputFirmata::internalReset()
+{
+    for (int i = 0; i < MAX_PWM_CHANNELS; i++)
+    {
+        if (_pwmChannelMap[i] != 255)
+        {
+            ledcDetachPin(_pwmChannelMap[i]);
+        }
+        _pwmChannelMap[i] = 255;
+    }
+}
+
+boolean AnalogOutputFirmata::handlePinMode(byte pin, int mode)
+{
+    if (mode == PIN_MODE_PWM && IS_PIN_PWM(pin)) {
+        setupPwmPin(pin);
+        return true;
+    }
+    int channel = 255;
+    // Unlink the channel for this pin
+    if (mode != PIN_MODE_PWM && (channel = getChannelForPin(pin)) != 255)
+    {
+        ledcDetachPin(pin);
+        _pwmChannelMap[channel] = 255;
+    }
+  return false;
+}
+
+void AnalogOutputFirmata::handleCapability(byte pin)
+{
+  if (IS_PIN_PWM(pin)) {
+    Firmata.write(PIN_MODE_PWM);
+    Firmata.write(DEFAULT_PWM_RESOLUTION);
+  }
+}
+
+boolean AnalogOutputFirmata::handleSysex(byte command, byte argc, byte* argv)
+{
+  if (command == EXTENDED_ANALOG) {
+    if (argc > 1) {
+      int val = argv[1];
+      if (argc > 2) val |= (argv[2] << 7);
+      if (argc > 3) val |= (argv[3] << 14);
+      analogWriteCallback(argv[0], val);
+      return true;
+    }
+    return false;
+  } else {
+    return handleAnalogFirmataSysex(command, argc, argv);
+  }
+}
+#endif

--- a/src/AnalogWrite.h
+++ b/src/AnalogWrite.h
@@ -31,7 +31,7 @@ void analogWriteCallback(byte pin, int value)
       case PIN_MODE_SERVO:
         if (IS_PIN_SERVO(pin)) {
           servoAnalogWrite(pin, value);
-          Firmata.setPinState(pin, value);
+          Firmata.setPinState(pin, PIN_MODE_SERVO);
         }
         break;
 #endif
@@ -39,7 +39,7 @@ void analogWriteCallback(byte pin, int value)
       case PIN_MODE_PWM:
         if (IS_PIN_PWM(pin)) {
           analogWrite(PIN_TO_PWM(pin), value);
-          Firmata.setPinState(pin, value);
+          Firmata.setPinState(pin, PIN_MODE_PWM);
         }
         break;
 #endif

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -260,6 +260,14 @@ void FirmataClass::processInput(void)
   }
 }
 
+void FirmataClass::resetParser()
+{
+    parsingSysex = false;
+    sysexBytesRead = 0;
+    waitForData = 0;
+    executeMultiByteCommand = 0;
+}
+
 /**
  * Parse data from the input stream.
  * @param inputData A single byte to be added to the parser.

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -67,7 +67,7 @@ FirmataClass::FirmataClass()
 {
   firmwareVersionMinor = 0;
   firmwareVersionMajor = 0;
-  firmwareVersionName = nullptr;
+  firmwareVersionName = "undefined";
   blinkVersionDisabled = false;
   systemReset();
 }
@@ -164,7 +164,7 @@ void FirmataClass::printFirmwareVersion(void)
 {
   byte i;
   int len;
-  if (firmwareVersionMajor != 0) { // make sure that the name has been set before reporting
+  if (firmwareVersionMajor != 0 && FirmataStream != nullptr) { // make sure that the name has been set before reporting
     startSysex();
     FirmataStream->write(REPORT_FIRMWARE);
     FirmataStream->write(firmwareVersionMajor); // major version number
@@ -187,7 +187,7 @@ void FirmataClass::printFirmwareVersion(void)
  */
 void FirmataClass::setFirmwareNameAndVersion(const char *name, byte major, byte minor)
 {
-  firmwareVersionName = (char*)name;
+  firmwareVersionName = name;
   firmwareVersionMajor = major;
   firmwareVersionMinor = minor;
 }

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -67,7 +67,7 @@ FirmataClass::FirmataClass()
 {
   firmwareVersionMinor = 0;
   firmwareVersionMajor = 0;
-  firmwareVersionName = "undefined";
+  firmwareVersionName = "";
   blinkVersionDisabled = false;
   systemReset();
 }

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -817,7 +817,7 @@ void FirmataClass::setPinState(byte pin, byte state)
 void FirmataClass::systemReset(void)
 {
   resetting = true;
-  byte i;
+  int i;
 
   waitForData = 0; // this flag says the next serial input will be data
   executeMultiByteCommand = 0; // execute this after getting multi-byte data

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -194,7 +194,7 @@ class FirmataClass
   private:
     Stream *FirmataStream;
     /* firmware name and version */
-    char *firmwareVersionName;
+    const char *firmwareVersionName;
     byte firmwareVersionMajor;
     byte firmwareVersionMinor;
     /* input message handling */

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -35,7 +35,11 @@
 #define FIRMATA_FIRMWARE_MINOR_VERSION  11 // for backwards compatible changes
 #define FIRMATA_FIRMWARE_BUGFIX_VERSION 0 // for bugfix releases
 
+#ifdef ESP32
+#define MAX_DATA_BYTES         255 // The ESP32 has enough RAM so we can reduce the number of packets, but the value must not exceed 2^8 - 1, because many methods use byte-indexing only
+#else
 #define MAX_DATA_BYTES          64 // max number of data bytes in incoming messages
+#endif
 
 // Arduino 101 also defines SET_PIN_MODE as a macro in scss_registers.h
 #ifdef SET_PIN_MODE

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -139,7 +139,7 @@ class FirmataClass
     /* Arduino constructors */
     void begin();
     void begin(long);
-    void begin(Stream &s);
+    void begin(Stream &s, bool isConsole = true);
     /* querying functions */
     void printVersion(void);
     void blinkVersion(void);
@@ -210,6 +210,10 @@ class FirmataClass
     byte pinState[TOTAL_PINS];           // any value that has been written
 
     boolean resetting;
+
+    // True if the current stream is also the console, 
+    // if false, we log information messages separately to the console
+    boolean outputIsConsole;
 
     /* callback functions */
     callbackFunction currentAnalogCallback;

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -151,6 +151,7 @@ class FirmataClass
     int available(void);
     void processInput(void);
     void parse(byte inputData);
+    void resetParser();
     boolean isParsingMessage(void);
     boolean isResetting(void);
     /* serial send handling */

--- a/src/utility/Boards.h
+++ b/src/utility/Boards.h
@@ -696,21 +696,22 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 // to not work after boot. 
 #define IS_PIN_DIGITAL(p)       ((p) == 0 || (p) == 2 || (p) == 4 || (p) == 5 || ((p) >= 12 && (p) < 24) || ((p) >= 25 && (p) < 28) || ((p) >= 32 && (p) <= 39))
 #define IS_PIN_ANALOG(p)        ((p) == 0 || (p) == 2 || (p) == 4 || (p) == 5 || ((p) >= 12 && (p) < 16) || ((p >= 25 && (p) < 28) || ((p) >= 32 && (p) < 37) || (p) == 39))
-#define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p) && digitalPinHasPWM(p))
+#define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p))
 #define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
-#define IS_PIN_I2C(p)           ((IS_PIN_DIGITAL(p)) && ((p == 21) || (p == 22)))
+#define IS_PIN_I2C(p)           ((p == 21) || (p == 22))
 #define IS_PIN_SPI(p)           (IS_PIN_DIGITAL(p) && digitalPinHasSPI(p))
 #define IS_PIN_INTERRUPT(p)     (digitalPinToInterrupt(p) > NOT_AN_INTERRUPT)
 #define IS_PIN_SERIAL(p)        (digitalPinHasSerial(p))
 #define PIN_TO_DIGITAL(p)       (p)
 #define PIN_TO_ANALOG(p)        digitalPinToAnalogChannel(p) // defined in esp32-hal-gpio.h
+// The ESP32 supports PWM on almost all pins, but only 16 pins can use pwm at once.
 #define PIN_TO_PWM(p)           (p)
 #define PIN_TO_SERVO(p)         (p)
-#define DEFAULT_PWM_RESOLUTION  8
+#define DEFAULT_PWM_RESOLUTION  13
 #define DEFAULT_ADC_RESOLUTION  12
 
 // Defined in AnalogOutputFirmata.cpp
-void analogWrite(uint8_t channel, uint32_t value, uint32_t valueMax = 255);
+void analogWrite(uint8_t channel, uint32_t value);
 
 // Adafruit Bluefruit nRF52 boards
 #elif defined(ARDUINO_NRF52_ADAFRUIT)


### PR DESCRIPTION
Fix PWM support on ESP32. Now supports PWM on all output pins, but only 16 pins can use PWM at once. 

Also improves logging for WiFi-connected ESP32