### PR TITLE
fix: setFirmwareNameAndVersion before begin

### DIFF
--- a/examples/ConfigurableFirmata/ConfigurableFirmata.ino
+++ b/examples/ConfigurableFirmata/ConfigurableFirmata.ino
@@ -213,9 +213,9 @@ void initFirmata()
 
 void setup()
 {
+	initFirmata();
 	initTransport();
 	Firmata.sendString(F("Booting device. Stand by..."));
-	initFirmata();
 
 	Firmata.parse(SYSTEM_RESET);
 


### PR DESCRIPTION
When init call begin(115200), it call printFirmwareVersion(). But if not call setFirmwareNameAndVersion before begin, it will not report to host. So the "ready" connect will fail on J5 or Firmata.js.

Read printFirmwareVersion function:
```
    if (firmwareVersionMajor != 0 && FirmataStream != nullptr) { // make sure that the name has been set before reporting
```