### PR TITLE
Several fixes to ESP32 "Analog In" feature

### DIFF
--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -21,9 +21,22 @@
 
 AnalogInputFirmata *AnalogInputFirmataInstance;
 
+static int AnalogToPin(int analogChannel)
+{
+    for (byte pin = 0; pin < TOTAL_PINS; pin++)
+    {
+        if (analogChannel == PIN_TO_ANALOG(pin))
+        {
+            return pin;
+        }
+    }
+
+    return 0;
+}
+
 void reportAnalogInputCallback(byte analogPin, int value)
 {
-  AnalogInputFirmataInstance->reportAnalog(analogPin, value);
+  AnalogInputFirmataInstance->reportAnalog(analogPin, value == 1, (byte)AnalogToPin(analogPin));
 }
 
 AnalogInputFirmata::AnalogInputFirmata()
@@ -36,23 +49,25 @@ AnalogInputFirmata::AnalogInputFirmata()
 // -----------------------------------------------------------------------------
 /* sets bits in a bit array (int) to toggle the reporting of the analogIns
  */
-//void FirmataClass::setAnalogPinReporting(byte pin, byte state) {
-//}
-void AnalogInputFirmata::reportAnalog(byte analogPin, int value)
+void AnalogInputFirmata::reportAnalog(byte analogPin, bool enable, byte physicalPin)
 {
   if (analogPin < TOTAL_ANALOG_PINS) {
-    if (value == 0) {
-      analogInputsToReport = analogInputsToReport & ~ (1 << analogPin);
-    } else {
-      analogInputsToReport = analogInputsToReport | (1 << analogPin);
-      // prevent during system reset or all analog pin values will be reported
-      // which may report noise for unconnected analog pins
-      if (!Firmata.isResetting()) {
-        // Send pin value immediately. This is helpful when connected via
-        // ethernet, wi-fi or bluetooth so pin states can be known upon
-        // reconnecting.
-        Firmata.sendAnalog(analogPin, analogRead(analogPin));
-      }
+    if (enable == false)
+	{
+        analogInputsToReport = analogInputsToReport & ~ (1 << analogPin);
+    } 
+	else 
+	{
+        analogInputsToReport = analogInputsToReport | (1 << analogPin);
+        // prevent during system reset or all analog pin values will be reported
+        // which may report noise for unconnected analog pins
+        if (!Firmata.isResetting()) 
+		{
+            // Send pin value immediately. This is helpful when connected via
+            // ethernet, wi-fi or bluetooth so pin states can be known upon
+            // reconnecting.
+		    Firmata.sendAnalog(analogPin, analogRead(physicalPin));
+        }
     }
   }
   // TODO: save status to EEPROM here, if changed
@@ -62,13 +77,13 @@ boolean AnalogInputFirmata::handlePinMode(byte pin, int mode)
 {
   if (IS_PIN_ANALOG(pin)) {
     if (mode == PIN_MODE_ANALOG) {
-      reportAnalog(PIN_TO_ANALOG(pin), 1); // turn on reporting
+      reportAnalog(PIN_TO_ANALOG(pin), true, pin); // turn on reporting
       if (IS_PIN_DIGITAL(pin)) {
         pinMode(PIN_TO_DIGITAL(pin), INPUT); // disable output driver
       }
       return true;
     } else {
-      reportAnalog(PIN_TO_ANALOG(pin), 0); // turn off reporting
+      reportAnalog(PIN_TO_ANALOG(pin), false, pin); // turn off reporting
     }
   }
   return false;
@@ -85,13 +100,6 @@ void AnalogInputFirmata::handleCapability(byte pin)
 boolean AnalogInputFirmata::handleSysex(byte command, byte argc, byte* argv)
 {
   if (command == ANALOG_MAPPING_QUERY) {
-	for (byte pin = 0; pin < TOTAL_PINS; pin++) {
-	  int mapped = PIN_TO_ANALOG(pin);
-	  if (mapped >= 0 && IS_PIN_ANALOG(pin))
-	  {
-		Firmata.sendStringf(F("Pin %d is mapped to analog channel A%d"), (int)pin, mapped);
-	  }
-    }
     Firmata.write(START_SYSEX);
     Firmata.write(ANALOG_MAPPING_RESPONSE);
     for (byte pin = 0; pin < TOTAL_PINS; pin++) {
@@ -99,6 +107,12 @@ boolean AnalogInputFirmata::handleSysex(byte command, byte argc, byte* argv)
     }
     Firmata.write(END_SYSEX);
     return true;
+  }
+  if (command == EXTENDED_REPORT_ANALOG && argc >= 2)
+  {
+  	byte analogChannel = argv[0];
+  	reportAnalog(analogChannel, argv[1] == 1, (byte)AnalogToPin(analogChannel));
+	return true;
   }
   return false;
 }
@@ -122,7 +136,7 @@ void AnalogInputFirmata::report(bool elapsed)
     if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {
       analogPin = PIN_TO_ANALOG(pin);
       if (analogInputsToReport & (1 << analogPin)) {
-        Firmata.sendAnalog(analogPin, analogRead(analogPin));
+        Firmata.sendAnalog(analogPin, analogRead(pin));
       }
     }
   }

--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -59,8 +59,7 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, bool enable, byte physical
 	else 
 	{
         analogInputsToReport = analogInputsToReport | (1 << analogPin);
-		Firmata.sendStringf(F("Enabling reporting on analog channel %d, physical pin %d, reports 0x%x"), analogPin, physicalPin, analogInputsToReport);
-        // prevent during system reset or all analog pin values will be reported
+		// prevent during system reset or all analog pin values will be reported
         // which may report noise for unconnected analog pins
         if (!Firmata.isResetting()) 
 		{
@@ -132,11 +131,6 @@ void AnalogInputFirmata::report(bool elapsed)
   }
 
   byte pin, analogPin;
-  if (analogInputsToReport)
-  {
-      Firmata.sendStringf(F("Attempting to report a change to pins 0x%x"), analogInputsToReport);
-  }
-
   /* ANALOGREAD - do all analogReads() at the configured sampling interval */
   for (pin = 0; pin < TOTAL_PINS; pin++) {
     if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {

--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -59,6 +59,7 @@ void AnalogInputFirmata::reportAnalog(byte analogPin, bool enable, byte physical
 	else 
 	{
         analogInputsToReport = analogInputsToReport | (1 << analogPin);
+		Firmata.sendStringf(F("Enabling reporting on analog channel %d, physical pin %d, reports 0x%x"), analogPin, physicalPin, analogInputsToReport);
         // prevent during system reset or all analog pin values will be reported
         // which may report noise for unconnected analog pins
         if (!Firmata.isResetting()) 
@@ -93,7 +94,7 @@ void AnalogInputFirmata::handleCapability(byte pin)
 {
   if (IS_PIN_ANALOG(pin)) {
     Firmata.write(PIN_MODE_ANALOG);
-    Firmata.write(10); // 10 = 10-bit resolution
+    Firmata.write(DEFAULT_ADC_RESOLUTION); // Defaults to 10-bit resolution
   }
 }
 
@@ -131,6 +132,11 @@ void AnalogInputFirmata::report(bool elapsed)
   }
 
   byte pin, analogPin;
+  if (analogInputsToReport)
+  {
+      Firmata.sendStringf(F("Attempting to report a change to pins 0x%x"), analogInputsToReport);
+  }
+
   /* ANALOGREAD - do all analogReads() at the configured sampling interval */
   for (pin = 0; pin < TOTAL_PINS; pin++) {
     if (IS_PIN_ANALOG(pin) && Firmata.getPinMode(pin) == PIN_MODE_ANALOG) {

--- a/src/AnalogInputFirmata.cpp
+++ b/src/AnalogInputFirmata.cpp
@@ -85,6 +85,13 @@ void AnalogInputFirmata::handleCapability(byte pin)
 boolean AnalogInputFirmata::handleSysex(byte command, byte argc, byte* argv)
 {
   if (command == ANALOG_MAPPING_QUERY) {
+	for (byte pin = 0; pin < TOTAL_PINS; pin++) {
+	  int mapped = PIN_TO_ANALOG(pin);
+	  if (mapped >= 0 && IS_PIN_ANALOG(pin))
+	  {
+		Firmata.sendStringf(F("Pin %d is mapped to analog channel A%d"), (int)pin, mapped);
+	  }
+    }
     Firmata.write(START_SYSEX);
     Firmata.write(ANALOG_MAPPING_RESPONSE);
     for (byte pin = 0; pin < TOTAL_PINS; pin++) {

--- a/src/AnalogInputFirmata.h
+++ b/src/AnalogInputFirmata.h
@@ -27,7 +27,7 @@ class AnalogInputFirmata: public FirmataFeature
 {
   public:
     AnalogInputFirmata();
-    void reportAnalog(byte analogPin, int value);
+    void reportAnalog(byte analogPin, bool enable, byte physicalPin);
     void handleCapability(byte pin);
     boolean handlePinMode(byte pin, int mode);
     boolean handleSysex(byte command, byte argc, byte* argv);

--- a/src/AnalogInputFirmata.h
+++ b/src/AnalogInputFirmata.h
@@ -35,7 +35,7 @@ class AnalogInputFirmata: public FirmataFeature
     void report(bool elapsed) override;
   private:
     /* analog inputs */
-    int analogInputsToReport; // bitwise array to store pin reporting
+    int analogInputsToReport; // bitwise array to store pin reporting (bit0 = A0, bit1 = A1, etc.)
 };
 
 #endif

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -446,8 +446,6 @@ boolean FirmataClass::isResetting(void)
  */
 void FirmataClass::sendAnalog(byte analogPin, int value)
 {
-    Firmata.sendStringf(F("Reporting analog channel %d, raw value %d"), (int)analogPin, value);
-
     if (analogPin <= 15)
     {
         // pin can only be 0-15, so chop higher bits

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -446,10 +446,22 @@ boolean FirmataClass::isResetting(void)
  */
 void FirmataClass::sendAnalog(byte analogPin, int value)
 {
-  // pin can only be 0-15, so chop higher bits
-  Firmata.sendStringf(F("Reporting analog channel %d, raw value %d"), (int)analogPin, value);
-  FirmataStream->write(ANALOG_MESSAGE | (analogPin & 0xF));
-  sendValueAsTwo7bitBytes(value);
+    Firmata.sendStringf(F("Reporting analog channel %d, raw value %d"), (int)analogPin, value);
+
+    if (analogPin <= 15)
+    {
+        // pin can only be 0-15, so chop higher bits
+        FirmataStream->write(ANALOG_MESSAGE | (analogPin & 0xF));
+        sendValueAsTwo7bitBytes(value);
+    }
+    else
+    {
+        startSysex();
+        FirmataStream->write(EXTENDED_ANALOG);
+        FirmataStream->write(analogPin);
+        sendValueAsTwo7bitBytes(value);
+        endSysex();
+    }
 }
 
 /* (intentionally left out asterix here)

--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -440,14 +440,15 @@ boolean FirmataClass::isResetting(void)
  * when using the ANALOG_MESSAGE. The maximum value of the ANALOG_MESSAGE is limited to 14 bits
  * (16384). To increase the pin range or value, see the documentation for the EXTENDED_ANALOG
  * message.
- * @param pin The analog pin to send the value of (limited to pins 0 - 15).
+ * @param analogChannel The analog pin to send the value of (limited to pins 0 - 15).
  * @param value The value of the analog pin (0 - 1024 for 10-bit analog, 0 - 4096 for 12-bit, etc).
  * The maximum value is 14-bits (16384).
  */
-void FirmataClass::sendAnalog(byte pin, int value)
+void FirmataClass::sendAnalog(byte analogPin, int value)
 {
   // pin can only be 0-15, so chop higher bits
-  FirmataStream->write(ANALOG_MESSAGE | (pin & 0xF));
+  Firmata.sendStringf(F("Reporting analog channel %d, raw value %d"), (int)analogPin, value);
+  FirmataStream->write(ANALOG_MESSAGE | (analogPin & 0xF));
   sendValueAsTwo7bitBytes(value);
 }
 

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -77,7 +77,7 @@
 #define CAPABILITY_RESPONSE     0x6C // reply with supported modes and resolution
 #define PIN_STATE_QUERY         0x6D // ask for a pin's current mode and value
 #define PIN_STATE_RESPONSE      0x6E // reply with pin's current mode and value
-#define EXTENDED_ANALOG         0x6F // analog write (PWM, Servo, etc) to any pin
+#define EXTENDED_ANALOG         0x6F // analog write (PWM, Servo, etc) to any pin or analog input from a pin > 15
 #define SERVO_CONFIG            0x70 // set max angle, minPulse, maxPulse, freq
 #define STRING_DATA             0x71 // a string message with 14-bits per char
 #define STEPPER_DATA            0x72 // control a stepper motor

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -32,7 +32,7 @@
  * Query using the REPORT_FIRMWARE message.
  */
 #define FIRMATA_FIRMWARE_MAJOR_VERSION  3 // for non-compatible changes
-#define FIRMATA_FIRMWARE_MINOR_VERSION  0 // for backwards compatible changes
+#define FIRMATA_FIRMWARE_MINOR_VERSION  1 // for backwards compatible changes
 #define FIRMATA_FIRMWARE_BUGFIX_VERSION 0 // for bugfix releases
 
 #ifdef LARGE_MEM_DEVICE
@@ -48,7 +48,7 @@
 #endif
 
 // message command bytes (128-255/0x80-0xFF)
-#define DIGITAL_MESSAGE         0x90 // send data for a digital pin
+#define DIGITAL_MESSAGE         0x90 // send data for a digital port (8 bits)
 #define ANALOG_MESSAGE          0xE0 // send data for an analog pin (or PWM)
 #define REPORT_ANALOG           0xC0 // enable analog input by pin #
 #define REPORT_DIGITAL          0xD0 // enable digital input by port pair
@@ -68,7 +68,7 @@
 #define ENCODER_DATA            0x61 // reply with encoders current positions
 #define ACCELSTEPPER_DATA       0x62 // control a stepper motor
 #define REPORT_DIGITAL_PIN      0x63 // (reserved)
-#define EXTENDED_REPORT_ANALOG  0x64 // (reserved)
+#define EXTENDED_REPORT_ANALOG  0x64 // Enable reporting analog channels > 15. Supported with v3.1 or later.
 #define REPORT_FEATURES         0x65 // (reserved)
 #define SPI_DATA                0x68 // SPI Commands start with this byte
 #define ANALOG_MAPPING_QUERY    0x69 // ask for mapping of analog to pin numbers

--- a/src/ConfigurableFirmata.h
+++ b/src/ConfigurableFirmata.h
@@ -22,12 +22,12 @@
  * Query using the REPORT_VERSION message.
  */
 #define FIRMATA_PROTOCOL_MAJOR_VERSION  2 // for non-compatible changes
-#define FIRMATA_PROTOCOL_MINOR_VERSION  6 // for backwards compatible changes
+#define FIRMATA_PROTOCOL_MINOR_VERSION  7 // for backwards compatible changes
 #define FIRMATA_PROTOCOL_BUGFIX_VERSION 0 // for bugfix releases
 
 /*
  * Version numbers for the Firmata library.
- * ConfigurableFirmata 3.0 implements version 2.6.0 of the Firmata protocol.
+ * ConfigurableFirmata 3.1 implements version 2.7.0 of the Firmata protocol.
  * The firmware version will not always equal the protocol version going forward.
  * Query using the REPORT_FIRMWARE message.
  */

--- a/src/utility/Boards.h
+++ b/src/utility/Boards.h
@@ -699,7 +699,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 // ESP32
 // GPIO 6-11 are used for FLASH I/O, therefore they're unavailable here
 #elif defined(ESP32)
-#define TOTAL_ANALOG_PINS       NUM_ANALOG_INPUTS
+#define TOTAL_ANALOG_PINS       20 /* Must be the largest Axx number, not NUM_ANALOG_INPUTS*/
 #define TOTAL_PINS              NUM_DIGITAL_PINS
 #define VERSION_BLINK_PIN       2
 #define digitalPinHasSPI(p)     ((p) == 12 || (p) == 13 || (p) == 14 || (p) == 15)
@@ -710,7 +710,7 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 // Pins 1 and 3 are used for the USB Serial communication. If we enable them here, the initial pin reset causes the serial communication
 // to not work after boot. 
 #define IS_PIN_DIGITAL(p)       ((p) == 0 || (p) == 2 || (p) == 4 || (p) == 5 || ((p) >= 12 && (p) < 24) || ((p) >= 25 && (p) < 28) || ((p) >= 32 && (p) <= 39))
-#define IS_PIN_ANALOG(p)        ((p) == 0 || (p) == 2 || (p) == 4 || (p) == 5 || ((p) >= 12 && (p) < 16) || ((p >= 25 && (p) < 28) || ((p) >= 32 && (p) < 37) || (p) == 39))
+#define IS_PIN_ANALOG(p)        ((p) == 0 || (p) == 2 || (p) == 4 || ((p) >= 12 && (p) < 16) || ((p >= 25 && (p) < 28) || ((p) >= 32 && (p) < 37) || (p) == 39))
 #define IS_PIN_PWM(p)           (IS_PIN_DIGITAL(p))
 #define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
 #define IS_PIN_I2C(p)           ((p == 21) || (p == 22))
@@ -809,6 +809,10 @@ static inline void attachInterrupt(pin_size_t interruptNumber, voidFuncPtr callb
 
 #ifndef DEFAULT_PWM_RESOLUTION
 #define DEFAULT_PWM_RESOLUTION  8
+#endif
+
+#ifndef DEFAULT_ADC_RESOLUTION
+#define DEFAULT_ADC_RESOLUTION 10 /* Uno, Due, etc by default report 10 bits, even if they can go higher*/
 #endif
 
 #define MODE_INPUT 0 /* Because the name INPUT causes conflicts compiling on Windows */

--- a/src/utility/Boards.h
+++ b/src/utility/Boards.h
@@ -701,7 +701,12 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #elif defined(ESP32)
 #define TOTAL_ANALOG_PINS       20 /* Must be the largest Axx number, not NUM_ANALOG_INPUTS*/
 #define TOTAL_PINS              NUM_DIGITAL_PINS
+#ifdef ARDUINO_M5STACK_Core2
+// Use an external pin - pin 2 is connected to the speaker
+#define VERSION_BLINK_PIN       27
+#else
 #define VERSION_BLINK_PIN       2
+#endif
 #define digitalPinHasSPI(p)     ((p) == 12 || (p) == 13 || (p) == 14 || (p) == 15)
 #define PIN_SPI_MOSI            13
 #define PIN_SPI_MISO            12


### PR DESCRIPTION
For some reason, the ESP32 reported an analog pin mapping for pins that aren't analog pins.

This causes the client to get incorrect pin mappings. Additionally, this adds the possibility
to address analog channels > 15 with the EXTENDED_ANALOG message.