### PR TITLE
SPI: fix bug in csPin data type

### DIFF
--- a/src/SpiFirmata.h
+++ b/src/SpiFirmata.h
@@ -40,7 +40,7 @@
 struct spi_device_config {
   byte deviceIdChannel;
   byte csPinOptions;
-  byte csPin;
+  char csPin;
   boolean packedData;
   SPISettings spi_settings;
   boolean used;


### PR DESCRIPTION
The data type of the csPin member of spi_device_config was wrong. The field will be set to -1 if no pin is set or manual cs-pin control is used. Then the comparisons with -1 in the code will not work as expected, see https://stackoverflow.com/questions/36770376/comparing-unsigned-char-to-a-negative-number

So we use "char" instead of "byte" and the code behaves as expected.