### PR TITLE
Handle zero-length SYSEX messages

### DIFF
--- a/src/ConfigurableFirmata.cpp
+++ b/src/ConfigurableFirmata.cpp
@@ -213,6 +213,10 @@ int FirmataClass::available(void)
  */
 void FirmataClass::processSysexMessage(void)
 {
+  if (sysexBytesRead == 0) {
+    return;
+  }
+
   switch (storedInputData[0]) { //first byte in buffer is command
     case REPORT_FIRMWARE:
       printFirmwareVersion();


### PR DESCRIPTION
Simple fix for #151. Check that the `storedInputData` buffer is not empty before reading the command ID from the buffer.

