### PR TITLE
Fix `#if` in AnalogOutputFirmata.h

### DIFF
--- a/src/AnalogOutputFirmata.h
+++ b/src/AnalogOutputFirmata.h
@@ -30,7 +30,7 @@ class AnalogOutputFirmata: public FirmataFeature
     void analogWriteInternal(byte pin, uint32_t value);
   private:
       void setupPwmPin(byte pin);
-#if ESP32
+#ifdef ESP32
       void internalReset();
 #endif
 	boolean handleSysex(byte command, byte argc, byte* argv)


### PR DESCRIPTION
The `void internalReset();` private member function of the AnalogOutputFirmata class is intended to only be defined if compiling on ESP32.

No other code in this library uses `#if ESP32`, they all use `#ifdef ESP32`. When changing this to use `#ifdef`, this successfully compiles in Arduino IDE 2.3.2. Previously, when using `#if`, this wasn't compiling and the compiler complained about there being no member function defined for the class.

Hopefully this works in other situations and doesn't break anything else.