### PR TITLE
Prevent out-of-bounds access of servo array

### DIFF
--- a/src/ServoFirmata.h
+++ b/src/ServoFirmata.h
@@ -130,6 +130,10 @@ void ServoFirmata::attach(byte pin, int minPulse, int maxPulse)
 
 void ServoFirmata::detach(byte pin)
 {
+  // Servo not available for this pin?
+  if (PIN_TO_SERVO(pin) >= sizeof(servos) / sizeof(servos[0])) {
+    return;
+  }
   Servo *servo = servos[PIN_TO_SERVO(pin)];
   if (servo) {
     if (servo->attached())


### PR DESCRIPTION
Attempt to fix #176. 

For the RPi Pico, `MAX_SERVOS` = 8 (using the Arduino-Pico core's Servo library) and `TOTAL_PINS = 30`.

The code just assumes that on every pin that *can* be a servo (`IS_PIN_SERVO()`), it can also use that pin as an index into the `servos` array (8 elements long) and call detach on it. This is wrong. In iteration pin = 8, it will grab `servos[8]` (an out of bounds read of that array), get back a not-null-pointer and call detach on that object, which hardfaults the Pico's processor.

This simple fix generically aborts execution if the index into the servos array would be out of bounds. For me, it then doesn't crash anymore.

See also discussion in https://github.com/earlephilhower/arduino-pico/discussions/2897.
