### PR TITLE
Fix: adjust sleep function for ESP32C3

### DIFF
--- a/src/ArduinoSleep.cpp
+++ b/src/ArduinoSleep.cpp
@@ -12,7 +12,11 @@ void ArduinoSleep::reset()
 #if defined(ESP32)
 void ArduinoSleep::EnterSleepMode()
 {
+#if defined(CONFIG_IDF_TARGET_ESP32C3) // https://github.com/espressif/arduino-esp32/issues/7005
+	esp_deep_sleep_enable_gpio_wakeup(1 << 9, ESP_GPIO_WAKEUP_GPIO_HIGH);
+#else
 	esp_sleep_enable_ext0_wakeup((gpio_num_t)_wakeupPin, _triggerValue); //1 = High, 0 = Low
+#endif
 	// If you were to use ext1, you would use it like
 	// esp_sleep_enable_ext1_wakeup(BUTTON_PIN_BITMASK,ESP_EXT1_WAKEUP_ANY_HIGH);
 


### PR DESCRIPTION
When ConfigurableFirmata (current `master`, Commit `538270b`) is built for an ESP32C3 board, the compiler fails:

```
libraries\ConfigurableFirmata\src\ArduinoSleep.cpp: In member function 'void ArduinoSleep::EnterSleepMode()':
libraries\ConfigurableFirmata\src\ArduinoSleep.cpp:15:9: error: 'esp_sleep_enable_ext0_wakeup' was not declared in this scope; did you mean 'esp_sleep_enable_bt_wakeup'?
   15 |         esp_sleep_enable_ext0_wakeup((gpio_num_t)_wakeupPin, _triggerValue); //1 = High, 0 = Low
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         esp_sleep_enable_bt_wakeup
```

Probably caused by https://github.com/espressif/arduino-esp32/issues/7005:
> esp32-c3 does not support rtc wakeup. esp_deep_sleep_enable_gpio_wakeup should work

This PR resolves the compile error.

I'm not sure if it's good style to check for `CONFIG_IDF_TARGET_ESP32C3`. An alternative would be a check of `ARDUINO_VARIANT` for `esp32c3`, but I don't know how to compare strings at preprocessing time.
